### PR TITLE
Bump SDK version to 1.11.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The original `srobbin/opengov-mcp-server` used `StdioServerTransport`, which is 
 *   **Node.js:** Version 18.19.1 (as per Render environment)
 *   **TypeScript:** For type safety and modern JavaScript features.
 *   **ES Modules (`type: "module"`):** In `package.json`.
-*   **`@modelcontextprotocol/sdk`:** Currently targeting version `1.11.4`.
+*   **`@modelcontextprotocol/sdk`:** Currently targeting version `1.11.5`.
 *   **HTTP Transport:** Currently implementing `StreamableHTTPServerTransport` with `express`.
 *   **Build Process:** `npm run build` (which runs `tsc`).
 *   **Deployment Platform:** Render.com (as a Web Service).

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.11.4",
+        "@modelcontextprotocol/sdk": "^1.11.5",
         "axios": "^1.8.4",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
@@ -723,8 +723,8 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.4.tgz",
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.5.tgz",
       "integrity": "sha512-OTbhe5slIjiOtLxXhKalkKGhIQrwvhgCDs/C2r8kcBTy5HR/g43aDQU0l7r8O0VGbJPTNJvDc7ZdQMdQDJXmbw==",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.11.4",
+    "@modelcontextprotocol/sdk": "^1.11.5",
     "axios": "^1.8.4",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ async function createLowLevelServerInstance(): Promise<Server> { // Return type 
         {
           name: UNIFIED_SOCRATA_TOOL.name,
           description: UNIFIED_SOCRATA_TOOL.description,
-          parameters: UNIFIED_SOCRATA_TOOL.parameters, // For SDK v1.11.4 spec
+          parameters: UNIFIED_SOCRATA_TOOL.parameters, // For SDK v1.11.5 spec
           inputSchema: UNIFIED_SOCRATA_TOOL.parameters, // For MCP Inspector v0.8.2 compatibility
         },
       ],


### PR DESCRIPTION
## Summary
- update dependency on `@modelcontextprotocol/sdk` to 1.11.5
- update README to mention SDK version 1.11.5
- update inline comment referencing SDK 1.11.5
- adjust package-lock.json to reference 1.11.5

## Testing
- `npm install --fetch-retries=0` *(fails: request to https://registry.npmjs.org/@modelcontextprotocol%2fsdk failed, reason: connect EHOSTUNREACH 172.24.0.3:8080)*
- `npm test` *(fails: Cannot find package 'supertest')*