### PR TITLE
Accept header shim for ChatGPT connector

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.11.5",
+    "@modelcontextprotocol/sdk": "^1.15.1",
     "axios": "^1.8.4",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,6 +228,15 @@ async function startApp() {
     };
 
     /* ── 2.  NO express.json() before /mcp!  ───────────────── */
+    // Accept-header shim for OpenAI connector
+    app.use(mcpPath, (req, _res, next) => {
+      const h = req.headers.accept ?? '';
+      if (!h.includes('text/event-stream')) {
+        req.headers.accept = h ? `${h}, text/event-stream` : 'text/event-stream';
+      }
+      next();
+    });
+
     app.all(mcpPath, (req: Request, res: Response) => {
       // Earliest log for any /mcp request
       console.log(`[Express /mcp ENTRY] Method: ${req.method}, URL: ${req.originalUrl}, Origin: ${req.headers.origin}`);


### PR DESCRIPTION
## Summary
- ensure the MCP endpoint accepts `text/event-stream`
- update `@modelcontextprotocol/sdk` to `^1.15.1`

## Testing
- `npm test` *(fails: Cannot find package 'supertest' & failing tests)*
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68704db675ac832b91125c519b556d87