### PR TITLE
Update MCP SDK and refresh build

### DIFF
--- a/.openai/setup_script.sh
+++ b/.openai/setup_script.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+npm install --include=dev
+npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.11.5",
+        "@modelcontextprotocol/sdk": "^1.15.0",
         "axios": "^1.8.4",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
@@ -634,15 +634,17 @@
       "dev": true
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.12.0.tgz",
-      "integrity": "sha512-m//7RlINx1F3sz3KqwY1WWzVgTcYX52HYk4bJ1hkBXV3zccAEth+jRvG8DBRrdaQuRsPAJOx2MH3zaHNCKL7Zg==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.15.1.tgz",
+      "integrity": "sha512-W/XlN9c528yYn+9MQkVjxiTPgPxoxt+oczfjHBDsJx0+59+O7B75Zhsp0B16Xbwbz8ANISDajh6+V7nIcPMc5w==",
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
         "pkce-challenge": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.15.1",
+    "@modelcontextprotocol/sdk": "^1.15.0",
     "axios": "^1.8.4",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",


### PR DESCRIPTION
## Summary
- bump `@modelcontextprotocol/sdk` to `^1.15.0`
- regenerate `package-lock.json`
- add a minimal setup script for reproducible builds

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687064a8469c832b9eaed594ba90b370