### PR TITLE
Add skill-guidance prompt with modality-aware composition

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,9 @@ import {
 import { z } from 'zod';
 import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { McpError, ErrorCode } from './utils/mcp-errors.js';
+import { BASE_SKILL } from './skills/base.js';
+import { WEB_SKILL } from './skills/web.js';
+import { LOCAL_SKILL } from './skills/local.js';
 
 // Workaround: Define schemas locally since they're not properly exported from SDK
 const ListPromptsRequestSchema = z.object({
@@ -41,6 +44,14 @@ const ReadResourceRequestSchema = z.object({
   method: z.literal("resources/read"),
   params: z.object({
     uri: z.string()
+  })
+});
+
+const GetPromptRequestSchema = z.object({
+  method: z.literal("prompts/get"),
+  params: z.object({
+    name: z.string(),
+    arguments: z.optional(z.record(z.string()))
   })
 });
 
@@ -66,6 +77,9 @@ async function createServer(transport?: OpenAICompatibleTransport): Promise<Serv
     }
   );
   
+  // Track transport type for modality inference in GetPrompt
+  const isHttpTransport = !!transport;
+
   // Store transport reference on server for initialize handler
   if (transport) {
     (server as any)._customTransport = transport;
@@ -248,6 +262,18 @@ async function createServer(transport?: OpenAICompatibleTransport): Promise<Serv
             required: true
           }
         ]
+      },
+      {
+        name: 'skill-guidance',
+        title: 'Socrata Query Skill Guidance',
+        description: 'Socrata query skill guidance composed for your context (web or local)',
+        arguments: [
+          {
+            name: 'modality',
+            description: 'web or local — if omitted, inferred from transport (HTTP → web, stdio → local)',
+            required: false
+          }
+        ]
       }
     ];
     
@@ -256,6 +282,85 @@ async function createServer(transport?: OpenAICompatibleTransport): Promise<Serv
     return {
       prompts
     };
+  });
+
+  // Handle GetPrompt
+  server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+    const promptName = request.params.name;
+    const args = request.params.arguments;
+    console.error(`[Server - GetPrompt] Request for prompt: ${promptName}, args:`, args);
+
+    if (promptName === 'skill-guidance') {
+      // Determine modality: explicit arg > transport inference
+      const modality = args?.modality || (isHttpTransport ? 'web' : 'local');
+      const overlay = modality === 'web' ? WEB_SKILL : LOCAL_SKILL;
+      console.error(`[Server - GetPrompt] Composing skill-guidance with modality: ${modality}`);
+
+      return {
+        description: `Socrata query skill guidance (${modality} mode)`,
+        messages: [
+          {
+            role: 'user' as const,
+            content: {
+              type: 'text' as const,
+              text: BASE_SKILL + '\n\n---\n\n' + overlay
+            }
+          }
+        ]
+      };
+    }
+
+    if (promptName === 'analyze_nyc_data') {
+      const topic = args?.topic || 'general NYC data';
+      const timePeriod = args?.time_period ? ` for ${args.time_period}` : '';
+      return {
+        description: `Analyze ${topic} from NYC Open Data`,
+        messages: [
+          {
+            role: 'user' as const,
+            content: {
+              type: 'text' as const,
+              text: `Search and analyze datasets about "${topic}"${timePeriod} from the NYC Open Data portal (data.cityofnewyork.us). Use the get_data tool to discover relevant datasets and run SoQL queries. Provide key findings with data tables and methodology.`
+            }
+          }
+        ]
+      };
+    }
+
+    if (promptName === 'find_dataset') {
+      const description = args?.description || 'data';
+      return {
+        description: `Find NYC datasets matching: ${description}`,
+        messages: [
+          {
+            role: 'user' as const,
+            content: {
+              type: 'text' as const,
+              text: `Help me find datasets on the NYC Open Data portal (data.cityofnewyork.us) that match this description: "${description}". Use the search tool to find relevant datasets and provide their names, IDs, and descriptions.`
+            }
+          }
+        ]
+      };
+    }
+
+    if (promptName === 'compare_neighborhoods') {
+      const metric = args?.metric || 'data';
+      const neighborhoods = args?.neighborhoods || 'all boroughs';
+      return {
+        description: `Compare ${metric} across ${neighborhoods}`,
+        messages: [
+          {
+            role: 'user' as const,
+            content: {
+              type: 'text' as const,
+              text: `Compare ${metric} across these NYC neighborhoods/boroughs: ${neighborhoods}. Use the NYC Open Data portal to find relevant datasets and run comparative queries. Present findings in a comparison table.`
+            }
+          }
+        ]
+      };
+    }
+
+    throw new Error(`Prompt not found: ${promptName}`);
   });
 
   // Handle ListResources

--- a/src/skills/base.ts
+++ b/src/skills/base.ts
@@ -1,0 +1,252 @@
+// Sourced from civic-ai-tools/docs/skills/base.md
+// Keep in sync — see civic-ai-tools/docs/skills/README.md for governance.
+
+export const BASE_SKILL = `# Socrata MCP Companion Skill — Base Guidance
+
+Universal guidance for querying Socrata open data portals through the Socrata MCP Server.
+
+## Purpose
+
+This skill provides specialized guidance for:
+- **Multi-Domain Support**: NYC, Chicago, SF, Seattle, LA, and other Socrata portals
+- **Intelligent Query Assessment**: Complexity evaluation before executing large queries
+- **Anti-Hallucination Protocols**: Strict adherence to actual query results
+- **Domain-Specific Workarounds**: Handling limitations across different Socrata implementations
+
+## Critical Requirements
+
+**ALWAYS:**
+- Assess query complexity before executing
+- Never hallucinate data — only report what tool calls return
+- Discover columns first — check schema before querying unfamiliar datasets
+- Show exact queries used
+- Use inline citations
+- Add date filters when querying large or high-volume datasets to avoid performance issues and overly broad results. Use the Date Range Guidelines table to pick an appropriate range. Tell the user you applied a date filter, why, and that they can ask for a different range or all-time data if needed.
+
+**NEVER:**
+- Invent data points
+- Extrapolate beyond actual records
+- Present findings without tool evidence
+- Query without column discovery
+
+## Query Complexity Assessment
+
+Evaluate complexity before executing, proceed silently if low risk.
+
+### GREEN (Low Risk) — Proceed Silently
+- Single city, <7 day range
+- 1–4 tool calls required
+- <50k estimated records
+
+### YELLOW (Medium Risk) — Brief Warning
+- 2+ cities OR full month range
+- 5–9 tool calls required
+- 50–150k estimated records
+
+### RED (High Risk) — Stop & Offer Options
+- 3+ cities with month+ ranges
+- 10+ tool calls required
+- >150k estimated records
+
+## Mandatory Column Discovery
+
+Before querying ANY unfamiliar dataset, discover the schema first:
+
+\\\`\\\`\\\`
+Tool: get_data
+Type: "query"
+Domain: [domain]
+Dataset_id: [dataset-id]
+Query: SELECT * LIMIT 1
+\\\`\\\`\\\`
+
+## Core SoQL Query Patterns
+
+### Basic Query Structure
+\\\`\\\`\\\`sql
+SELECT field1, field2, field3
+WHERE condition
+ORDER BY field1
+LIMIT 1000
+\\\`\\\`\\\`
+
+### Common Filter Patterns
+\\\`\\\`\\\`sql
+-- Text search
+WHERE field ILIKE '%search_term%'
+
+-- Date ranges
+WHERE date_field >= '2023-01-01' AND date_field < '2024-01-01'
+
+-- Numeric ranges
+WHERE amount > 1000 AND amount < 10000
+
+-- Multiple values
+WHERE status IN ('Active', 'Pending', 'Approved')
+\\\`\\\`\\\`
+
+### Aggregation Patterns
+\\\`\\\`\\\`sql
+SELECT department, COUNT(*) as count, SUM(amount) as total
+GROUP BY department
+ORDER BY total DESC
+\\\`\\\`\\\`
+
+### Time Series Analysis
+\\\`\\\`\\\`sql
+SELECT date_trunc_y(date_field) as year,
+       COUNT(*) as annual_count
+GROUP BY year
+ORDER BY year
+\\\`\\\`\\\`
+
+## Supported Domains
+
+| Domain | get_data | search | fetch | Status |
+|--------|----------|--------|-------|--------|
+| data.cityofnewyork.us | Full | Full | Full | Fully Compatible |
+| data.cityofchicago.org | Full | Full | Full | Fully Compatible |
+| data.sfgov.org | Full | Limited | Unknown | Query-Preferred |
+| data.seattle.gov | Full | Full | Full | Fully Compatible |
+| data.lacity.org | Full | Limited | Fails | Query-Only |
+
+### Domain-Specific Workarounds
+
+**San Francisco (data.sfgov.org):**
+- Search tool sometimes returns NYC data instead of SF
+- Use web search to find SF dataset IDs, then use get_data
+
+**Los Angeles (data.lacity.org):**
+- Only get_data works; search and fetch tools fail
+- Use web search to find LA dataset IDs, then use get_data exclusively
+
+**Known LA Dataset IDs:**
+- MyLA311 2025: h73f-gn57
+- MyLA311 2022: i5ke-k6by
+- MyLA311 2020: rq3b-xjk8
+
+## Date Range Guidelines
+
+| Dataset Type | Volume | Single City Range | Multi-City Range |
+|--------------|--------|-------------------|------------------|
+| NYC 311 | ~10k/day | Up to 30 days | Up to 7 days |
+| Chicago 311 | ~5k/day | Up to 30 days | Up to 14 days |
+| LA 311 | ~4k/day | Up to 30 days | Up to 14 days |
+| Seattle 311 | ~1.5k/day | Up to 90 days | Up to 30 days |
+| SF 311 | ~2k/day | Up to 60 days | Up to 30 days |
+| Housing Violations | ~500–1k/day | Up to 90 days | Up to 30 days |
+| Building Permits | ~200–800/day | Up to 180 days | Up to 90 days |
+| Business Licenses | ~50–200/day | Up to 1 year | Up to 180 days |
+
+## NYC Open Data Key Datasets
+
+### 311 Service Requests (erm2-nwe9)
+- Key fields: complaint_type, borough, created_date, closed_date
+- Common filters: complaint type, borough, date range
+- Aggregations: by complaint type, by borough, daily/weekly trends
+
+### Restaurant Inspections (43nn-pn8j)
+- Key fields: boro, grade, inspection_date, cuisine_description
+- Common filters: borough, grade, date range
+
+### Housing Violations (wvxf-dwi5)
+- Key fields: boro, violationid, inspectiondate
+- Common filters: borough, violation type, date range
+
+### Budget Data (d52a-yn36)
+- Key fields: agency_name, budget_amount, fiscal_year
+- Common filters: fiscal year, agency type
+
+### Payroll Data (k397-673e)
+- Key fields: agency_name, title_description, base_salary
+- Common filters: agency, title, salary range
+
+## Error Handling
+
+### Common Socrata API Errors
+
+**400 Bad Request** — SoQL syntax errors
+- Check field names (case-sensitive)
+- Validate data types in comparisons
+- Ensure proper quoting of string values
+
+**404 Not Found** — Dataset ID or domain issues
+- Verify dataset ID format (4x4 pattern: abcd-1234)
+- Confirm domain is correct
+- Check if dataset is public/accessible
+
+**429 Too Many Requests** — Rate limiting
+- Implement delays between requests
+- Use Socrata App Token for higher limits
+
+**500 Server Error** — Complex queries or server issues
+- Simplify query complexity
+- Reduce result set size with LIMIT
+- Retry with exponential backoff
+
+## Socrata MCP Server Tools
+
+| Tool | Purpose | Returns |
+|------|---------|---------|
+| **search** | Find datasets or search within a dataset | Encoded IDs |
+| **fetch** | Retrieve full metadata or records | Complete data with metadata |
+| **get_data** | Execute SoQL queries (recommended) | Raw query results |
+
+## Output Format Guidelines
+
+### Standard Output Structure
+
+# [Analysis Title]
+
+## Key Metrics
+[Visual comparison table]
+
+## Executive Summary
+[2–3 paragraphs: findings, significance]
+
+## Detailed Analysis
+[Analysis with inline calculations]
+
+## Methodology
+### Data Sources
+[Datasets, date ranges, record counts]
+
+### Queries Used
+| Purpose | Records | Query |
+|---------|---------|-------|
+| [Purpose] | [Count] | SELECT... |
+
+## Uncertainty & Limitations Disclosure
+
+When presenting analysis, include structured caveats so users know what they can and can't conclude:
+
+- **Data completeness**: State what the results cover — e.g., "This covers 12,430 of ~300k annual records (last 30 days)." If you applied filters, say so.
+- **Field interpretation**: When a query depends on interpreting the user's intent as a specific field or value, say so — e.g., "I interpreted 'noise' as complaint_type ILIKE '%noise%' — verify this matches your intent."
+- **Limitations section**: End analysis responses with a brief **Limitations** block listing anything that qualifies the findings: date range used, missing fields, sample size, portal quirks, etc.
+
+## Data Quality Checks
+
+Always check for:
+1. **Null Values**: WHERE field IS NOT NULL
+2. **Data Freshness**: Check last_updated or similar fields
+3. **Completeness**: Count missing vs. total records
+4. **Consistency**: Validate against known constraints
+
+## Advanced Techniques
+
+### Spatial Queries
+\\\`\\\`\\\`sql
+SELECT *
+WHERE within_circle(location, 40.7128, -74.0060, 1000)
+\\\`\\\`\\\`
+
+### Complex Aggregations
+\\\`\\\`\\\`sql
+SELECT category,
+       COUNT(*) as total_requests,
+       COUNT(CASE WHEN status = 'Closed' THEN 1 END) as closed_requests,
+       AVG(CASE WHEN closed_date IS NOT NULL
+           THEN (closed_date - created_date) END) as avg_resolution_days
+GROUP BY category
+ORDER BY total_requests DESC
+\\\`\\\`\\\``;

--- a/src/skills/local.ts
+++ b/src/skills/local.ts
@@ -1,0 +1,33 @@
+// Sourced from civic-ai-tools/docs/skills/local.md
+// Keep in sync — see civic-ai-tools/docs/skills/README.md for governance.
+
+export const LOCAL_SKILL = `# Socrata MCP Skill — Local Overlay
+
+> Applies to: Local CLI clients (Claude Code, Cursor, Copilot) via stdio transport.
+
+## Date Defaults
+
+Use the Date Range Guidelines table in the base guidance as a starting point, but you have more flexibility:
+
+- For single-city queries, you can extend ranges beyond the table defaults if the user's question warrants it. Just warn about potentially large result sets.
+- For multi-city queries, stick closer to the table defaults but don't hard-block longer ranges — warn and proceed if the user confirms.
+- If the user asks for all-time data, go ahead — just note the dataset size and how long the query may take.
+
+## Full Capabilities
+
+Local clients have no demo constraints. You can:
+
+- **Cross-portal comparisons**: Encouraged! Comparing 311 data across NYC, Chicago, SF, etc. is one of the most valuable use cases. Query each portal and synthesize findings.
+- **Extended analysis**: Longer responses with full methodology sections, detailed tables, and comprehensive findings are fine.
+- **Multiple tool calls**: No artificial limit — use as many tool calls as the analysis requires.
+- **Large result sets**: Query up to the Socrata API limits (50,000 rows per request). Use pagination for larger datasets.
+
+## Output Format
+
+Use the full output structure from the base guidance including:
+- Key Metrics table
+- Executive Summary
+- Detailed Analysis
+- Full Methodology section with data sources and queries used
+
+For complex analyses, consider breaking results into sections the user can explore further.`;

--- a/src/skills/web.ts
+++ b/src/skills/web.ts
@@ -1,0 +1,38 @@
+// Sourced from civic-ai-tools/docs/skills/web.md
+// Keep in sync — see civic-ai-tools/docs/skills/README.md for governance.
+
+export const WEB_SKILL = `# Socrata MCP Skill — Web Overlay
+
+> Applies to: Web demo (civicaitools.org) and other HTTP-connected clients.
+
+## Date Filter Enforcement
+
+**ALWAYS add a date filter** on high-volume datasets (>1M rows, e.g., 311 data) unless the user explicitly asks for all-time data. Default to **30 days** for 311-type datasets. This is mandatory — the web environment has tighter resource constraints than local tools.
+
+If a user's question is open-ended (e.g., "What are the top complaints in NYC?"), default to the last 30 days and tell them:
+- That you scoped to the last 30 days for performance
+- They can ask for a different range
+- For all-time analysis, suggest using the local CLI tools
+
+## Web Demo Limits
+
+This is a public demo with shared resources. Enforce these limits:
+
+- **Result sets**: Limit queries to 10,000 rows max. If more data is needed, suggest narrowing the date range or filters.
+- **Tool calls per response**: Keep to 5 or fewer tool calls. If a query would require more, simplify or break it into follow-up questions.
+- **Response length**: Keep responses concise and token-conscious. Prefer tables and bullet points over long prose. Aim for key findings, not exhaustive analysis.
+- **No cross-portal comparisons**: Do not compare data across multiple cities in a single response. Each city query consumes resources — suggest the user ask about one city at a time, or use the local CLI tools for multi-city analysis.
+
+## Token-Conscious Formatting
+
+- Lead with the answer, then supporting data
+- Use compact tables rather than verbose explanations
+- Limit to 3–5 key findings per response
+- Skip the full "Methodology" section — include a brief "Data source" line instead
+- Omit the "Queries Used" table unless the user asks for it
+
+## Local Tools CTA
+
+When a user hits a limit (complex multi-city query, long date range, deep analysis), suggest:
+
+> For more complex analysis — like cross-city comparisons, longer date ranges, or deeper dives — try the Civic AI Tools CLI (https://github.com/npstorey/civic-ai-tools), which connects directly to these same data sources with no demo limits.`;


### PR DESCRIPTION
## Summary

- Adds a `skill-guidance` MCP prompt that serves composed skill guidance (base + web/local overlay)
- Modality is inferred from transport type (HTTP → web, stdio → local) or passed explicitly as a prompt argument
- Adds `GetPrompt` handler for all 4 prompts (3 existing + new `skill-guidance`)
- Skill content is embedded at build time in `src/skills/` (sourced from `civic-ai-tools/docs/skills/`)

## Context

Part of civic-ai-tools#24 — refactoring skill guidance into structured base + modality overlays served via MCP prompts. This is the server-side piece (Session 3a).

Companion PR: npstorey/civic-ai-tools#25 (skill file split)

## Test plan

- [ ] `npm run build` compiles cleanly
- [ ] `prompts/list` returns 4 prompts including `skill-guidance`
- [ ] `prompts/get` with `name: "skill-guidance"` returns base + web overlay (HTTP) or base + local overlay (stdio)
- [ ] `prompts/get` with `modality: "local"` override returns base + local even over HTTP
- [ ] Existing 3 prompts still work via `prompts/get`

🤖 Generated with [Claude Code](https://claude.com/claude-code)