### PR TITLE
docs+fix: README env truth-pass; record session timestamps under the id in use

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,16 @@ git clone https://github.com/npstorey/socrata-mcp-server.git
 cd socrata-mcp-server
 npm install
 npm run build
-npm run dev   # Starts on http://localhost:10000
+npm run dev   # Starts on http://localhost:10000 (with PORT=10000 from .env)
 ```
 
 ### Environment variables
 
 ```bash
 # .env
-PORT=10000
+PORT=10000                                     # Project convention (local dev + Render). The code falls back to 8000 if PORT is unset.
 DATA_PORTAL_URL=https://data.cityofnewyork.us  # Default portal (optional)
+SOCRATA_APP_TOKEN=                             # Optional Socrata app token, sent as X-App-Token on portal requests for higher rate limits. Without it, portals apply stricter anonymous throttling.
 ```
 
 ## Available tools

--- a/src/index.ts
+++ b/src/index.ts
@@ -1135,7 +1135,7 @@ async function startApp() {
           try {
             const parsed = typeof currentRequestBody === 'string' ? JSON.parse(currentRequestBody) : currentRequestBody;
             if (parsed.method) {
-              lastResponseTimestamps.set(sessionId, {
+              lastResponseTimestamps.set(currentSessionId, {
                 method: parsed.method,
                 timestamp: Date.now()
               });


### PR DESCRIPTION
Q2 close-out hygiene batch for this repo: README env truth-pass + one telemetry-only fix.

## What

1. **README environment section** — documents that `PORT=10000` is the project convention (local dev + Render) while the code falls back to 8000 when `PORT` is unset (`src/index.ts`), and documents `SOCRATA_APP_TOKEN` (read in `src/utils/api.ts`, sent as `X-App-Token`) — previously the variable an external operator most needs was absent from the README.
2. **Session-timestamp key fix** — the timing map keyed entries by the request-header session id where `currentSessionId` (computed two lines above, with the transport fallback) was intended; newly created sessions recorded their first response under `undefined`. Telemetry-only; no auth or data-path impact.

## Verification

- `npm run build` — clean
- `npm test` — 80 passed, 9 skipped (13 files passed, 2 skipped)

Note: merging to main auto-deploys to Render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
