### PR TITLE
Light housekeeping pass: skill-guidance provenance, four-repo routing (civic-ai-tools#134)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,7 @@ Test your changes by interacting with the server through Claude Desktop:
 
 - `src/index.ts` - MCP server initialization and request handling
 - `src/tools/socrata-tools.ts` - The unified `get_data` tool implementation
+- `src/skills/` - **generated; do not hand-edit.** Committed copies of `civic-ai-tools/docs/skills/{base,local,web}.md`, emitted by that repo's `scripts/check-skill-drift.mjs --emit`. The `civic-ai-tools` CI fails on any byte-level divergence. Edit the source in `civic-ai-tools` and land the regenerated copies here as a follow-up PR.
 - `src/utils/` - Helper functions and type definitions
 - `src/__tests__/` - Test files
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ SOCRATA_APP_TOKEN=                             # Optional Socrata app token, sen
 | `search` | Search for datasets or records, returns ID/score pairs |
 | `fetch` | Retrieve full dataset metadata or records by ID |
 
+### Skill guidance
+
+The server also serves composed skill guidance to clients via the MCP `prompts/get` endpoint (`skill-guidance` prompt). **`src/skills/*.ts` are generated, not authored here** — the source of truth is [`civic-ai-tools/docs/skills/`](https://github.com/npstorey/civic-ai-tools/tree/main/docs/skills), and that repo's CI byte-compares the two. Guidance changes start with a PR to that repo.
+
 ## Supported portals
 
 Works with any Socrata-powered open data portal. Some popular ones:
@@ -85,6 +89,8 @@ Works with any Socrata-powered open data portal. Some popular ones:
 
 The deployed instance at `https://socrata-mcp-server.onrender.com` powers [civicaitools.org](https://civicaitools.org).
 
+To run your own hosted instance, [`render.yaml`](render.yaml) mirrors the deployed instance's Render configuration and can be used as a Render Blueprint; any host that can run `npm run build && npm start` with `PORT` set will do.
+
 ## Development
 
 ```bash
@@ -96,10 +102,13 @@ npm run lint      # Lint
 
 ## Related projects
 
+This server is one of four repositories in the Civic AI Tools / Typed Standards project. Analyses run through it can be packaged as signed, independently verifiable evidence; [civic-ai-tools](https://github.com/npstorey/civic-ai-tools) is the hub for that architecture.
+
 | Repository | Description |
 |-----------|-------------|
 | [civic-ai-tools](https://github.com/npstorey/civic-ai-tools) | Starter project that bundles this server with Data Commons MCP for multi-source civic data queries |
 | [civic-ai-tools-website](https://github.com/npstorey/civic-ai-tools-website) | Demo website at [civicaitools.org](https://civicaitools.org) — side-by-side comparison of AI with and without live data |
+| [typedstandards](https://github.com/npstorey/typedstandards) | The Typed Standards home — verification/producer cores and [typedstandards.org](https://typedstandards.org) |
 | [odp-mcp](https://github.com/socrata/odp-mcp) | Socrata's official MCP server (similar functionality, different implementation) |
 
 ## Contributing


### PR DESCRIPTION
Docs-only PR executing the owner-approved LIGHT housekeeping pass for this repo — rows 15–18 of the approved edit list in npstorey/civic-ai-tools#134.

## Changes

- **Row 15 — README, "Skill guidance" subsection** (after the Available tools table): documents that the server serves composed skill guidance via the MCP `prompts/get` endpoint (`skill-guidance` prompt — verified against the GetPrompt handler in `src/index.ts`), that `src/skills/*.ts` are generated rather than authored here, and that guidance changes start with a PR to `civic-ai-tools`.
- **Row 16 — CONTRIBUTING, Project Structure**: adds a `src/skills/` entry — generated, do not hand-edit; emitted by `civic-ai-tools`'s `scripts/check-skill-drift.mjs --emit` (verified against the generated files' own header comments); regenerated copies land here as a follow-up PR.
- **Row 17 — README, Related projects**: lead-in sentence placing this server as one of the four project repos, plus a `typedstandards` row.
- **Row 18 — README, Transport section**: pointer to `render.yaml` for running your own hosted instance, plus the generic `npm run build && npm start` host requirement (script names verified against `package.json`).

## Verification notes (claims corrected during drafting)

- The byte-compare CI lives in **civic-ai-tools' CI** (its `check:skill-drift` step fetches this repo's `main`), not this repo's `ci.yml` — both new passages attribute it to that repo so contributors don't expect this repo's PR CI to catch drift.
- `render.yaml`'s own header describes it as a mirror of the dashboard configuration (documentation-as-code, adopted as a Blueprint only via explicit sync), so the README pointer says it "mirrors the deployed instance's Render configuration and can be used as a Render Blueprint" rather than calling it a live blueprint.

No changes outside README.md and CONTRIBUTING.md; `src/` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
