### PR TITLE
chore: align @types/node with the declared Node floor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       "devDependencies": {
         "@types/cors": "^2.8.18",
         "@types/express": "^4.17.0",
-        "@types/node": "^18.0.0",
+        "@types/node": "^22.0.0",
         "@types/supertest": "^6.0.3",
         "@typescript-eslint/eslint-plugin": "^8.29.0",
         "@typescript-eslint/parser": "^8.29.0",
@@ -39,7 +39,7 @@
         "vitest": "^3.1.1"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1138,12 +1138,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.19.103",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.103.tgz",
-      "integrity": "sha512-hHTHp+sEz6SxFsp+SA+Tqrua3AbmlAw+Y//aEwdHrdZkYVRWdvWD3y5uPZ0flYOkgskaFWqZ/YGFm3FaFQ0pRw==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/qs": {
@@ -4349,10 +4350,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/cors": "^2.8.18",
     "@types/express": "^4.17.0",
-    "@types/node": "^18.0.0",
+    "@types/node": "^22.0.0",
     "@types/supertest": "^6.0.3",
     "@typescript-eslint/eslint-plugin": "^8.29.0",
     "@typescript-eslint/parser": "^8.29.0",


### PR DESCRIPTION
Follow-up to #49. That PR recorded the Node runtime floor (`engines.node: ">=22.0.0"`, `.node-version`, `render.yaml`); this one makes the *compiler* agree with it.

## The mismatch

`devDependencies` pinned `@types/node: ^18.0.0` while the repo declares `>=22.0.0` and CI, Render, and local dev all run Node 22. So `tsc` was validating `src/` against the Node 18 API surface while the code runs on 22.

Zero runtime risk — types are erased at build. The cost is that typecheck was checking the wrong contract in both directions: it would not have flagged a Node 18-only API as unavailable on the floor, and it would have rejected a legitimate Node 22 API as nonexistent.

## Measurement

`npx tsc --noEmit`, on the same tree, only the types package changing:

| | `@types/node` | errors |
|---|---|---|
| Before | 18.19.103 | **0** |
| After | 22.20.1 | **0** |

Nothing to classify — no mechanical fixes, no structural ones, no casts, no suppressions. The diff is the version range and the lockfile.

That zero is meaningful rather than vacuous because of #48: deleting the two ambient `any`-typed SDK shims brought this repo to a genuinely clean baseline days ago, so the bump was measured against a real zero and not a noise floor. `npm run build`, `npm run lint` (0 errors, 117 pre-existing warnings), and `npm test` are unchanged.

### Scope note: the test files are outside `tsc`'s program

`tsconfig.json` excludes `src/**/*.test.ts` and `src/__tests__`, so the 0-error result above covers the 15 production source files, not the tests. Measured separately with a scratch config that includes them, the test surface carries **11 pre-existing errors** — and the error sets at 18 and at 22 are byte-identical, so none of them are attributable to this change. They are unrelated to Node types: `ajv`/`ajv-formats` ESM-interop constructability (`TS2351`/`TS2349`), the MCP SDK's `capabilities.roots` shape (`TS2353`), two `TS2589` deep-instantiation hits, and some `possibly undefined` on inferred schema literals. Recording them here as inventory for the dependency work in civic-ai-tools#131; they are out of scope for this PR.

## Why `^22.0.0` and not the newest major

Types should track the **declared floor**, not the newest release, so the compiler stops you from reaching for an API your minimum supported runtime does not have. `engines.node` says `>=22.0.0`, so the types range mirrors it exactly. Jumping to `^24` would reintroduce the same class of mismatch this PR closes, just pointed the other way — the compiler would cheerfully accept APIs that a conforming Node 22 host does not ship, and the failure would land at runtime instead of at typecheck.

The range floor is `^22.0.0` rather than `^22.20.1` for the same reason: `22.0.0` describes the narrower, older Node 22 surface, which is the conservative choice against a `>=22.0.0` floor. The lockfile pins 22.20.1, the version actually validated here.

## Duplication check

`npm ls @types/node` — no hoisting or duplication hazard, before or after. Every consumer (`@types/cors`, `@types/express` and its transitive `@types/*`, `@types/supertest` → `@types/superagent`, `vitest`, `vite`) resolves `deduped` to the single root copy. They declare `@types/node: *`, so they follow the root pin rather than pulling a second major:

```
├── @types/node@22.20.1
├─┬ @types/express@4.17.22
│ ├─┬ @types/body-parser@1.19.5
│ │ └── @types/node@22.20.1 deduped
...
└─┬ vitest@3.1.4
  ├── @types/node@22.20.1 deduped
  └─┬ vite@6.3.5
    └── @types/node@22.20.1 deduped
```

`undici-types` moves `5.26.5` → `6.21.0` as a transitive consequence — it is `@types/node`'s own types-only dependency, dev-only, not in the runtime graph.

## Incidental fix

The relock corrects the lockfile's mirrored root `engines` field, which #49 left at `>=18.0.0` when it updated `package.json`. Cosmetic — npm reads the manifest, not the mirror — but it removes a stale contradiction between the two files.

## Verification

Run on Node v22.23.1:

- `npx tsc --noEmit` — 0 errors
- `npm run build` — clean
- `npm run lint` — 0 errors, 117 warnings (all pre-existing `no-explicit-any` / `no-unused-vars`)
- `npm test` — 79 passed, 9 skipped; 4 failures in `openai-initialize.test.ts`, all `listen EPERM` from the local sandbox denying socket binds. Environmental, not code — `build-test-lint` is the authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
