### PR TITLE
config: rebuild CLAUDE.md from blank, add a path-scoped rule, agents and committed settings (Round 1)

### DIFF
--- a/.claude/agents/cold-read.md
+++ b/.claude/agents/cold-read.md
@@ -1,0 +1,47 @@
+---
+name: cold-read
+description: Fresh-context reviewer for a finished PR in this repo — reads only the diff, the repo's docs, and the stated acceptance criteria, and reports gaps that affect correctness or the stated requirements. Fixes nothing.
+---
+
+You are a cold reader. Your value is that you did not watch the work happen.
+
+**What you read:** the PR diff, the repo's own documentation (`CLAUDE.md`,
+`.claude/rules/`, `CONTRIBUTING.md`, `README.md`, `render.yaml`'s comments where the
+diff touches deployment), and the acceptance criteria you were given. That is the
+whole inventory.
+
+**What you must not read:** the implementation chat, the ORCH transcript, the phase
+contract's reasoning, or any account of how the change came to be. If someone offers
+you that context, decline it. A verdict coloured by the author's assumptions is the
+one thing a cold read cannot produce.
+
+**What you report:** gaps that affect **correctness** or **the stated requirements**.
+Specifically:
+
+- a stated acceptance criterion the diff does not actually meet;
+- a defect in the changed code — wrong behaviour, an unhandled case, a broken
+  invariant;
+- a claim in the diff (a comment, a doc line, a commit message, a PR-body assertion)
+  that is false against the code at this revision;
+- a check the criteria required that the evidence does not show being run;
+- a change to a tool schema or response shape whose cross-repo consumers the diff does
+  not account for — the website's chat surface, and the embedded skill copies.
+
+**What you leave alone:** style, naming, structure you would have done differently,
+refactors the criteria did not ask for, the pre-existing lint warnings, and anything
+outside the diff. Preference is not a finding.
+
+**You fix nothing.** No edits, no commits, no pushes, no suggested patches applied.
+Your output is a report.
+
+Your report:
+
+1. **What I ran** — the exact commands and their results, or an explicit statement
+   that you ran nothing and reviewed by reading only.
+2. **Findings** — most severe first. Each one: file and line, what is wrong, and the
+   concrete scenario in which it is wrong. If a finding is a suspicion rather than a
+   confirmation, label it as such.
+3. **Criteria** — each stated acceptance criterion, marked met / not met / cannot tell
+   from the diff, with one line of reasoning.
+4. **Nothing found** is a complete and useful report. Say it plainly; do not
+   manufacture findings to justify the pass.

--- a/.claude/agents/impl.md
+++ b/.claude/agents/impl.md
@@ -1,0 +1,49 @@
+---
+name: impl
+description: IMPL agent for one gated-sprint phase in this repo — implements the phase on its own branch and reports evidence per CLAUDE.md. Spawned by an ORCH session with a phase contract from a sprint anchor issue.
+---
+
+You are the IMPL agent for exactly one phase of a gated sprint in `socrata-mcp-server`.
+
+Your phase contract arrives from the ORCH session: task, context, non-goals, binary
+acceptance criteria with runnable checks, blast zone, riders. This file is the
+standing part — what is true of every phase here regardless of what the contract says.
+
+Ground rules:
+
+- **Read before porting — verify, don't trust.** Read the sprint contract (anchor
+  issue) and your phase definition, then the referenced source material itself. A
+  premise in the contract that does not match the repo at HEAD gets flagged, not
+  silently resolved. Paths, commands, and line references in a contract are claims to
+  check, not facts to act on.
+- **One branch per phase**, named as the phase plan specifies; PR to `main`. You do
+  not merge, do not push tags, and do not deploy — ORCH handles merge and tags on
+  evidence-pass, and Render auto-deploys `main`. Never push to `main`.
+- **Stay inside the declared blast zone.** Keep the diff confined to the paths the
+  phase names; repos and paths the contract marks read-only stay untouched.
+  Out-of-scope findings go in the phase report as flags for later phases — do not fix
+  them. The 117 pre-existing lint warnings are the standing example: not yours to
+  clear.
+- **Follow CLAUDE.md**: the stakeholder boundary (neutral phrasing in every artifact
+  that lands in this public repo) and secret hygiene — never read `.env*`. Read the
+  `.claude/rules/` entries for the paths you are touching; `src/skills/` in particular
+  is generated and is never edited here. `git commit -s` on every commit — the
+  `Signed-off-by:` email must match the commit author email exactly.
+- **Never bypass a guard.** If a hook or the pre-push guard blocks, resolve the cause
+  and rebuild the branch history so the flagged bytes never land in outgoing commits.
+  Surface the block in your report; escalate to the owner rather than working around it.
+
+Phase report (your final message, mirrored into the PR body):
+
+- branch + diff stat, with an explicit blast-zone statement;
+- full output of every check CI gates on, pasted rather than summarized:
+  `npm run clean && npm run build:tsc`, `npm test`, `npm run lint`. Run `npm ci`
+  first — a stale `node_modules` produces failures that look like code defects — and
+  state the healthy baselines you measured against (`Test Files 15 passed | 2 skipped`,
+  lint `0 errors, 117 warnings`);
+- the model you ran on;
+- everything flagged-not-fixed, and every contract premise that did not survive the
+  check.
+
+Report outcomes faithfully — a red test, a skipped step, or a partial phase is
+reported as such, never smoothed over.

--- a/.claude/rules/skills.md
+++ b/.claude/rules/skills.md
@@ -1,0 +1,50 @@
+---
+paths:
+  - "src/skills/**"
+---
+
+# Skill guidance — generated, three surfaces
+
+`src/skills/base.ts`, `web.ts`, `local.ts` and `web-reference-demo.ts` are
+**generated; do not hand-edit.** Each carries the header saying so. `compose.ts` is
+ordinary source and is the exception — it holds the composition logic, not guidance.
+
+The same guidance exists on three surfaces, and they are not peers:
+
+1. **Source of truth** — `civic-ai-tools/docs/skills/{base,web,local,web-reference-demo}.md`.
+   Guidance changes are reviewed in a PR to *that* repo.
+2. **This server's embedded copies** — `src/skills/*.ts`, rendered from the source by
+   `node scripts/check-skill-drift.mjs --emit <dir>` in `civic-ai-tools`, and landed
+   here as a follow-up PR. `civic-ai-tools` CI fails on any byte-level divergence,
+   fetching these files from the public repo to compare.
+3. **The website's fallback** — `civic-ai-tools-website/src/lib/mcp/socrata-skill.ts`,
+   used only when this server's `prompts/get` endpoint is unreachable. It is
+   deployment-neutral by design and is **hand-shaped under its own test coverage**,
+   not regenerated from the emitter.
+
+So: never edit `src/skills/*.ts` directly, and never transcribe by hand — edit the
+source in `civic-ai-tools`, re-emit, and land the emitted bytes.
+<!-- the drift check exists because the copies drifted before it did; hand transcription is the specific failure it was built to catch -->
+
+## Composition and `SKILL_POSTURE`
+
+`compose.ts` assembles what a client receives from the `skill-guidance` prompt:
+
+- **base** is always included;
+- **one modality overlay** — HTTP transport → `web`, stdio → `local`. Modality
+  resolution stays in `src/index.ts`; `compose.ts` receives an already-resolved
+  modality and must not re-infer it;
+- **one optional posture overlay** — with `SKILL_POSTURE=reference-demo` *and*
+  modality `web`, `web-reference-demo` is appended after `web`.
+
+Posture is additive and owner-gated. It never applies to `local`. An unrecognized
+`SKILL_POSTURE` **fails open** to the generic composition and logs a warning — it does
+not throw.
+<!-- fail-open is deliberate: a typo'd posture value must not take the public demo's guidance offline -->
+
+## Protocol vocabulary stays put
+
+`org.civicaitools.summary` and `org.civicaitools.notebook` are reverse-DNS extension
+keys owned by the project and identical across every deployment, whatever its posture.
+A deployment renames its chrome, not these keys.
+<!-- typedstandards' canonicalization fingerprints org.civicaitools.notebook; renaming it per-deployment would break verification of records produced elsewhere -->

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "sandbox": {
+    "_shakedown": "Measured 2026-08-22 with enabled:true committed. The sandbox never reached the check set: it failed to initialize, verbatim — `Sandbox is enabled but failed to initialize: EPERM: operation not permitted, listen '/tmp/claude-501/srt-mux-<pid>-1.sock'. Sandboxing is disabled for the rest of this session; restart to retry.` Reproduced twice with different pids, so it is not a stale-socket collision; /tmp/claude-501 is 0700, so it is not a directory-permission problem either. Hence enabled:false. TWO CAVEATS BEFORE YOU FLIP IT BACK. (1) Both measurements ran in a NESTED session (`claude -p` spawned from inside another session), because a top-level session reads sandbox settings only at startup — writing this file mid-session does not activate it (probed: a non-allowlisted domain still resolved 200). A fresh top-level session may well initialize cleanly. (2) This repo had no trust record in ~/.claude.json at the time, so a nested run rooted here ignored this file entirely; the quoted failure was captured in the sibling typedstandards repo, which was trusted, against an identical sandbox block. To re-measure: start a fresh session here with enabled:true, accept the trust prompt, run `npm ci` then the three CI gates in CLAUDE.md, and record the result. Do not measure by flipping the setting inside a running session — enabling once is sticky for the rest of it. The allowlist and excludedCommands below are unmeasured for the same reason.",
+    "enabled": false,
+    "allowUnsandboxedCommands": false,
+    "excludedCommands": ["gh *", "git *"],
+    "filesystem": {
+      "allowWrite": ["~/.npm"]
+    },
+    "network": {
+      "allowedDomains": [
+        "registry.npmjs.org",
+        "github.com",
+        "api.github.com",
+        "objects.githubusercontent.com",
+        "codeload.github.com",
+        "data.cityofnewyork.us"
+      ]
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,61 +1,80 @@
-# Claude Project Primer - Socrata MCP Server
+# CLAUDE.md — Socrata MCP Server
 
-## Project overview
+MCP server for open data on Socrata-powered portals. Two transports: stdio (local CLI
+clients) and Streamable HTTP (web clients). The reference deployment runs on Render at
+`https://socrata-mcp.civicaitools.org/mcp` and powers the live demo at civicaitools.org;
+its Render-issued hostname is still the pre-rename `opengov-mcp-server.onrender.com`.
 
-MCP server for accessing open data on Socrata-powered portals. Supports stdio and HTTP (Streamable HTTP) transports.
+Tool surface: `SOCRATA_TOOLS` in `src/tools/socrata-tools.ts`, registered in
+`src/index.ts`. Read those rather than a list here.
+<!-- the table this replaces named three tools and their purposes — a second copy of the schemas, with nothing keeping it honest -->
 
 ## Strategic context — what not to include in this repo
 
-This repo is public. Strategic and relationship context — specific external stakeholders, prospective collaborators, pre-meeting strategy, private outreach plans, named individuals' opinions or quotes — lives in local-only planning docs outside this repo (workspace `CLAUDE.md`, `ROADMAP.md`, per-user auto-memory), not here.
+This repo is public. Strategic and relationship context — named external stakeholders,
+prospective collaborators, pre-meeting strategy, private outreach plans, individuals'
+opinions or quotes — lives in local-only planning docs outside this repo, not here.
 
-When contributing code, docs, commit messages, issue bodies, PR descriptions, or starter prompts for implementation chats that will commit to this repo, use neutral phrasing: "an external stakeholder," "an upcoming demo," "a follow-up meeting" — not specific names. If a task prompt you received includes strategic context, scrub it before producing any content destined for this repo.
+In code, docs, commit messages, issue bodies, PR descriptions, or starter prompts
+destined for this repo, use neutral phrasing: "an external stakeholder," "an upcoming
+demo," "a follow-up meeting." Scrub strategic context out of a task prompt before
+producing anything that lands here.
+<!-- a public repo's history is permanent: an unannounced partner name cannot be taken back once pushed -->
 
-## Key commands
+## Build / test
 
-```bash
-npm run build     # Clean build (tsc)
-npm run dev       # Start locally on http://localhost:10000
-npm run start     # Production mode
-npm test          # Run tests (vitest)
-```
+Node is pinned in `.node-version` (22); CI reads that file. Under a version manager a
+non-interactive shell has no `node` on `PATH` — load it first: `eval "$(fnm env)" && fnm use 22`.
+<!-- the sibling repo's ts#52 gate: every step exited 127 on a green branch and was reported as a failing gate -->
 
-## Architecture
+The three CI gates (`.github/workflows/ci.yml`), with what a pass looks like:
 
-- `src/index.ts` — Server entry point, tool/prompt/resource handlers
-- `src/mcp/tools/socrata.ts` — Socrata API tool implementations
-- `src/openai-compatible-transport.ts` — HTTP transport wrapper (session injection for header-less clients) over the SDK's Streamable HTTP transport
-- `src/tools/socrata-tools.ts` — Tool schema definitions
-- `src/utils/api.ts` — Socrata API client
-- `src/utils/portal-info.ts` — Portal metadata utilities
+- `npm run clean && npm run build:tsc` — `tsc --outDir dist`, silent on success. CI runs
+  those two pieces rather than `npm run build`, whose `prebuild-check` step dumps ~1,100
+  lines of SDK diagnostics and produces no artifacts.
+- `npm test` — `Test Files 15 passed | 2 skipped (17)`, `Tests 92 passed | 9 skipped (101)`.
+  The 9: 6 live-API integration tests behind `RUN_INTEGRATION=1` (`npm run
+  test:integration`), and 3 hardcoded `.skip`s in the transport-sequence tests.
+- `npm run lint` — a pass here is **`✖ 117 problems (0 errors, 117 warnings)`** with
+  exit 0. The warnings are pre-existing; don't clear them as a side effect of another
+  change.
+  <!-- measured 2026-08-22: a green lint here is not silent, and reading the ✖ line as failure invites an out-of-scope sweep -->
 
-## Tools
-
-| Tool | Purpose |
-|------|---------|
-| `get_data` | Unified access: catalog search, metadata, SoQL queries, metrics |
-| `search` | Search datasets/records, returns ID/score pairs |
-| `fetch` | Retrieve full metadata/records by ID |
+`npm run dev` runs the built `dist/` with dotenv loaded, so build first.
 
 ## Environment
 
-```bash
-PORT=10000
-DATA_PORTAL_URL=https://data.cityofnewyork.us
-SKILL_POSTURE=       # Optional. Unset -> generic web skill overlay; `reference-demo` -> demo-posture overlay appended for web modality (the reference deployment sets this). Unrecognized values fail open to generic with a logged warning.
-```
+- `DATA_PORTAL_URL` — **required**; any Socrata portal, e.g.
+  `https://data.cityofnewyork.us`. `src/utils/portal-info.ts` throws when it is unset.
+- `PORT` — HTTP transport port. Default **8000** in code (`src/index.ts`); the Render
+  deployment supplies its own.
+- `SKILL_POSTURE` — optional; deployment posture overlay. Semantics in
+  [`.claude/rules/skills.md`](.claude/rules/skills.md).
 
-## Deployment
+## Architecture
 
-- Deployed on Render: `https://socrata-mcp-server.onrender.com`
-- Powers the live demo at [civicaitools.org](https://civicaitools.org)
+- `src/index.ts` — entry point: tool/prompt/resource handlers, both transports.
+- `src/openai-compatible-transport.ts` — HTTP transport wrapper (session injection for
+  header-less clients) over the SDK's Streamable HTTP transport.
+- `src/skills/` — **generated; do not hand-edit.** The sync rule is in
+  [`.claude/rules/skills.md`](.claude/rules/skills.md).
+- `src/tools/`, `src/utils/`, `src/schema/` — tool schemas and handlers; Socrata API
+  client, cache and portal metadata; shared request schemas.
 
-## Architecture documentation
+Cross-repo architecture documents and spec drafts live in the hub repo at
+[`civic-ai-tools/docs/architecture/`](https://github.com/npstorey/civic-ai-tools/tree/main/docs/architecture)
+— this server is L1 of the standards stack. Before changing a tool schema or response
+shape, check whether the spec or that directory's `open-questions.md` constrains it.
+<!-- both spec drafts are internal working drafts; a shape changed here that the spec pins is a cross-repo break, and the check is cheap -->
 
-Cross-repo architecture documents and spec drafts live in the hub repo at [`civic-ai-tools/docs/architecture/`](https://github.com/npstorey/civic-ai-tools/tree/main/docs/architecture). The Typed Standards Specification governs the shape of record packages produced from MCP tool calls (this server is L1 of the standards stack — see `end-state-vision.md` §1). When changing tool schemas, response shapes, or trace-relevant attributes (`mcp.source`, etc.), check whether the change is constrained by spec sections or by open questions in [`open-questions.md`](https://github.com/npstorey/civic-ai-tools/blob/main/docs/architecture/open-questions.md). Both spec drafts are internal working drafts (pre-v0.1, not for external review). The project's working method for moving questions through to resolution is documented in [`working-method.md`](https://github.com/npstorey/civic-ai-tools/blob/main/docs/architecture/working-method.md) (companion to `xanadu-doctrine.md`); the third companion doctrine, [`chat-type-taxonomy.md`](https://github.com/npstorey/civic-ai-tools/blob/main/docs/architecture/chat-type-taxonomy.md), governs which kind of conversation (strategic, planning, orchestration, implementation, meta) is appropriate for which kind of work.
+## Merges and sign-off
+
+Work lands via PRs to `main`; never push to `main`. `git commit -s` on every commit —
+the `Signed-off-by:` email must match the commit author email exactly, or DCO fails
+(absence is not the only way to fail it). See [CONTRIBUTING.md](CONTRIBUTING.md).
+<!-- charter-5 in the sibling repo: two branches came back merge-blocked with CI otherwise green and had to be rebased with --signoff -->
 
 ## Related repos
 
-| Repo | Purpose |
-|------|---------|
-| [civic-ai-tools](https://github.com/npstorey/civic-ai-tools) | Starter project, MCP configs, skill docs |
-| [civic-ai-tools-website](https://github.com/npstorey/civic-ai-tools-website) | Demo website |
+[civic-ai-tools](https://github.com/npstorey/civic-ai-tools) — hub: skill sources, MCP configs,
+architecture docs. [civic-ai-tools-website](https://github.com/npstorey/civic-ai-tools-website) — the demo site.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,12 @@ Here are some areas where contributions would be particularly valuable:
 - Additional example use cases
 - Improved documentation
 
+## If you use Claude Code
+
+Cloning this repo installs its checked-in Claude Code configuration: `.claude/settings.json` (a network allowlist and a sandbox block), plus the agent definitions in `.claude/agents/` and the path-scoped rules in `.claude/rules/`.
+
+Those files are ordinary JSON and Markdown — read them before you trust them, the same as any other code you clone. Personal overrides belong in `.claude/settings.local.json`, which is gitignored.
+
 ## This is a multi-repo project
 
 This MCP server is one part of a larger project. If you're unsure where to contribute, see the [civic-ai-tools CONTRIBUTING guide](https://github.com/npstorey/civic-ai-tools/blob/main/CONTRIBUTING.md) for an overview of all four repos.


### PR DESCRIPTION
Way of Working v2, **Round 1 — the project layer** for this repo. The plan of record is the v2 audit artifact's "Config layers" and "The rebuild procedure" sections.

**Model:** Opus 5 (1M context) — `claude-opus-5[1m]`. One IMPL chat, this repo and `typedstandards` (separate PR).

**Blast zone:** `CLAUDE.md`, `CONTRIBUTING.md`, `.claude/**`. No source, test, workflow, or package manifest touched. `src/skills/` — the generated files — is untouched, as is `render.yaml`.

```
 .claude/agents/cold-read.md | 47 +++++++++++++++++++++
 .claude/agents/impl.md      | 49 ++++++++++++++++++++++
 .claude/rules/skills.md     | 50 +++++++++++++++++++++++
 .claude/settings.json       | 22 ++++++++++
 CLAUDE.md                   | 99 +++++++++++++++++++++++++++------------------
 CONTRIBUTING.md             |  6 +++
 6 files changed, 233 insertions(+), 40 deletions(-)
```

---

## The guardrail

A line survives only if removing it would cause a mistake, and every surviving rule cites its incident in an HTML comment. The comments are stripped before injection, so the citations cost nothing at boot.

`wc -l CLAUDE.md` — **80**, against the ≤ 80 ceiling. Up from 61, and the growth is worth naming honestly: it is entirely healthy-output lines, the rule citations, and two corrected premises, against three cuts. This file was under-specified rather than bloated — `typedstandards`' was the model, and this one had no equivalent of its evidence discipline.

## Premise checks — two things the old file asserted that are false at HEAD

Both were stated as fact and neither survived a check against the code:

1. **"Deployed on Render: `https://socrata-mcp-server.onrender.com`"** — that hostname is not the deployment. The reference deployment is `https://socrata-mcp.civicaitools.org/mcp` (`scripts/smoke-deployed-endpoint.mjs:54`, `render.yaml`), and the Render-issued hostname is the pre-rename `opengov-mcp-server.onrender.com` (`README.md:93`). A session told to probe the deployed endpoint from CLAUDE.md would have probed a host that isn't it.
2. **`npm run dev  # Start locally on http://localhost:10000`** — `PORT` defaults to **8000** in `src/index.ts:640` (`Number(process.env.PORT) || 8000`). 10000 was a suggested environment-file value presented as the default. `npm run dev` also runs the built `dist/`, so it needs a build first — the old line implied it starts from source.

A third, smaller one: `npm run build  # Clean build (tsc)` omitted `prebuild-check`, the ~1,100-line SDK diagnostic dump that sits between `clean` and `build:tsc` and is exactly why CI runs the two halves separately.

## What was cut

One line per cut, as the contract asks.

| Cut | Why |
|---|---|
| The three-row tool table (`get_data`, `search`, `fetch`) | Derivable from `SOCRATA_TOOLS` in `src/tools/socrata-tools.ts`. A second copy of the schemas with nothing keeping it honest; replaced by a two-line pointer at the export |
| The architecture-documentation paragraph (~230 words, seven links) | Down to two pointer lines: the hub `docs/architecture/` directory, and "check whether the spec or `open-questions.md` constrains it" before changing a schema or response shape |
| `src/mcp/tools/socrata.ts` — "Socrata API tool implementations" | Misleading: the live implementations are in `src/tools/socrata-tools.ts`. See *Flagged, not fixed* |
| `src/utils/api.ts` and `src/utils/portal-info.ts` as separate architecture rows | Folded into one line covering `src/tools/`, `src/utils/`, `src/schema/` — the split told you nothing `ls` doesn't |
| The `SKILL_POSTURE` semantics comment inside the environment block | Moved to `.claude/rules/skills.md`, where it fires when you touch `src/skills/**`; CLAUDE.md keeps the variable name and a pointer |
| The Related-repos table | Two lines of prose; a two-row table earned nothing |

No "use `-a`" / "annotated tags only" prose existed in this file to cut.

## What was added

- **The three CI gates** with what a pass looks like. The load-bearing one: a green `npm run lint` here prints **`✖ 117 problems (0 errors, 117 warnings)`** and exits 0. Silence is not the pass signal, and reading that `✖` as failure invites an out-of-scope warning sweep.
- **`npm test`'s real shape** — `15 passed | 2 skipped (17)` files, `92 passed | 9 skipped (101)` tests, with the 9 accounted for: 6 live-API integration tests behind `RUN_INTEGRATION=1`, 3 hardcoded `.skip`s in the transport-sequence tests. A session that sees skips and doesn't know they're expected either chases them or hides them.
- **The version-manager PATH line** (cited to the sibling repo's ts#52 gate, where every step exited 127 on a green branch).
- **A merges-and-sign-off section** — PRs to `main`, never push to `main`, `git commit -s` with the email-match requirement. The DCO requirement was only in `CONTRIBUTING.md`; a session reading CLAUDE.md alone did not see it.
- `DATA_PORTAL_URL` marked **required**, with the file that throws when it isn't set.

The stakeholder paragraph is kept — same boundary, tightened wording, and now carries why: a public repo's history is permanent.

## Rule, agents, settings

- **`.claude/rules/skills.md`** (`src/skills/**`) — the three-surface sync rule, stated as a hierarchy rather than a list: the hub's `docs/skills/*.md` is the source of truth; this repo's `src/skills/*.ts` are emitted by `check-skill-drift.mjs --emit` and byte-checked by the hub's CI; the website's `src/lib/mcp/socrata-skill.ts` is a deployment-neutral fallback that is **hand-shaped under its own tests**, not regenerated from the emitter. Plus the `SKILL_POSTURE` composition semantics (base + one modality overlay + one optional posture overlay; posture never applies to `local`; an unrecognized value fails open with a warning), that `compose.ts` is the one non-generated file in that directory, and that the `org.civicaitools.*` extension keys are protocol vocabulary that no deployment renames.
- **`.claude/agents/impl.md`** added, modelled on `typedstandards`': no `model:` field, so it inherits from the ORCH's per-phase choice; contract premises named as claims to check; the exact CI check set in the phase report, with the healthy baselines to measure against; never push to `main`; never bypass a guard. The 117 pre-existing lint warnings are named as the standing example of *not yours to clear*.
- **`.claude/agents/cold-read.md`** added — reads only the diff, the repo's docs and the stated criteria; flags only gaps affecting correctness or the stated requirements; fixes nothing. It carries one repo-specific lens: a tool-schema or response-shape change whose cross-repo consumers the diff doesn't account for.
- **`.claude/settings.json` committed** — the network allowlist (`data.cityofnewyork.us` kept) and the sandbox block, lifted out of `settings.local.json`. The ops-repo deny is **not** carried over: it is a fact about this machine, not this repo, and now lives in the global layer. `settings.local.json` had no `additionalDirectories`, so nothing was left to keep in it; it is now reduced to its `$schema` line. (Deleting it outright is blocked by the harness, which protects that file from removal. It is gitignored either way, so none of this is in the diff.) `CONTRIBUTING.md` gains two lines saying that cloning installs these.

## Sandbox shakedown

Committed **`enabled: false`**, with the failure quoted in `settings.json`'s `_shakedown` field. Measured once with `enabled: true` committed; the sandbox never reached the check set:

```
Sandbox is enabled but failed to initialize: EPERM: operation not permitted,
listen '/tmp/claude-501/srt-mux-<pid>-1.sock'. Sandboxing is disabled for the
rest of this session; restart to retry.
```

Reproduced twice with different pids, so not a stale-socket collision; `/tmp/claude-501` is `0700`, so not a directory-permission problem.

**Two caveats, both recorded in the file:** (1) both measurements ran in a *nested* session, because a top-level session reads sandbox settings only at startup — writing the file mid-session does not activate it (probed: a non-allowlisted domain still resolved 200). (2) This repo had **no trust record** in the user-level project registry at the time, so a nested run rooted here ignored the new settings file entirely; the quoted failure was captured in the sibling `typedstandards` checkout, which was trusted, against an identical sandbox block. The `_shakedown` note carries the re-measurement procedure — including accepting the trust prompt first.

## Memory dispositions

**None to sort.** This repo has no memory slug — no `~/.claude/projects/…socrata…` directory exists. Nothing to graduate, delete, or keep. The nine files in `typedstandards`' slug are dispositioned in that repo's PR.

Worth noting as a gap rather than a task: sessions rooted here have never accumulated a feedback memory, which is why facts like the 117-warning lint baseline and the `PORT` default had no home until this PR.

## Evidence

**Full CI check set, green at this tree** (`npm ci` first, Node 22 per `.node-version`):

```
npm run clean && npm run build:tsc     exit 0   (tsc --outDir dist, silent)
npm test                               exit 0
   Test Files  15 passed | 2 skipped (17)
        Tests  92 passed | 9 skipped (101)
     Duration  722ms
npm run lint                           exit 0
   ✖ 117 problems (0 errors, 117 warnings)
```

The 117 warnings are the pre-existing baseline, unchanged by this PR — it touches no `.ts` file.

**Statements pass — 91/91** across both repos' new files. For this repo: every script name, `.node-version`, both CI step strings, every referenced path, `SOCRATA_TOOLS`'s export, the `PORT` default read out of `src/index.ts`, the `DATA_PORTAL_URL` throw in `src/utils/portal-info.ts`, the reference endpoint in the smoke script, the "do not hand-edit" header on each of the four generated skill files and its absence on `compose.ts`, the three composition semantics quoted from `compose.ts`'s own header, the website fallback's HAND-SHAPED marker, the emitter's `--emit` flag, and the `org.civicaitools.notebook` key in `typedstandards`' `canonicalization.ts`.

**`claude doctor`** before and after: "No installation issues found" both times, unchanged.

**Fixture provenance:** none — this PR adds no fixtures.

**Worktrees:** `git worktree prune` removed one stale detached worktree (`48837ca`), left behind by an Aug-12 audit under a scratchpad path that no longer exists.

## Flagged, not fixed

- **`src/mcp/tools/socrata.ts` appears to be dead code.** 60 lines, exports `GetDataArgs` and friends, imported by nothing in `src/` (grepped). The old CLAUDE.md listed it as "Socrata API tool implementations", which is why the line is cut rather than corrected. Deleting it is a source change and outside this PR's blast zone.
- `claude doctor`'s CLI form only checks installation health; the config checkup that proposes trims is the in-session `/doctor`, which is interactive-only — `claude -p "/doctor"` produced no output in eight minutes. The before/after above is the CLI form. The interactive checkup is owed and needs the owner.
- Out of scope here, surfaced by the nested measurement: two deny entries in the **global** settings (`Write(**/.env)`, `Write(~/code/civic-ai-ops/**)`) are inert as written — file permission checks match `Edit(path)` rules only. That is a `claude-config` change.
