### PR TITLE
the text this server sends names the portal it is configured for (#61, Wave N10 P-S1)

### DIFF
--- a/src/__tests__/portal-text.test.ts
+++ b/src/__tests__/portal-text.test.ts
@@ -258,4 +258,40 @@ describe('advertised text describes the configured portal', () => {
       });
     });
   }
+
+  describe('the pre-rename identifiers still resolve', () => {
+    // The prompt name and the resource URIs that named a city were renamed, not
+    // interpolated — an identifier that moved with DATA_PORTAL_URL would not be
+    // an identifier. The old forms are accepted so a client that hardcoded one
+    // keeps working. Without these three assertions that compatibility path is
+    // code nothing drives.
+    beforeAll(() => {
+      process.env.DATA_PORTAL_URL = PORTALS[0].url;
+    });
+
+    it('serves the pre-rename analyze prompt name', async () => {
+      const got = await client.getPrompt({ name: 'analyze_nyc_data', arguments: { topic: 'noise' } });
+      expect(got.messages[0].content.type).toBe('text');
+      expect(String(got.messages[0].content.text)).toContain(PORTALS[0].domain);
+    });
+
+    it('serves the pre-rename resource URIs', async () => {
+      for (const suffix of ['portal-overview', 'popular-datasets', 'api-guide']) {
+        const got = await client.readResource({ uri: `data://nyc/info/${suffix}` });
+        expect(got.contents).toHaveLength(1);
+        // The response carries the current URI, so nothing this server sends
+        // spells the old one back at the client.
+        expect(got.contents[0].uri).toBe(`data://portal/info/${suffix}`);
+      }
+    });
+
+    it('advertises only the current identifiers', async () => {
+      const prompts = await client.listPrompts();
+      expect(prompts.prompts.map((p) => p.name)).not.toContain('analyze_nyc_data');
+      const resources = await client.listResources();
+      for (const resource of resources.resources) {
+        expect(resource.uri.startsWith('data://portal/info/')).toBe(true);
+      }
+    });
+  });
 });

--- a/src/__tests__/portal-text.test.ts
+++ b/src/__tests__/portal-text.test.ts
@@ -1,0 +1,261 @@
+/**
+ * The text this server sends a client or a model must describe the portal it is
+ * actually configured for (server#61, widened at Wave N10 P-S1).
+ *
+ * WHAT THIS GUARD ASSERTS OVER — and why it is shaped this way.
+ *
+ * It drives the real `createServer()` from `src/index.ts` over an in-memory
+ * transport with a real MCP `Client`, and asserts over the JSON-RPC responses
+ * that come back: `tools/list`, `prompts/list`, `prompts/get` (every prompt),
+ * `resources/list` and `resources/read` (every resource). It never imports
+ * `SEARCH_TOOL.description` — or any other constant under test — into its own
+ * expectation. Every existing assertion in this suite did exactly that
+ * (`tools-schema-validation.test.ts`, `openai-mcp-integration.test.ts`,
+ * `socrata-tools.test.ts`), which is why the strings could have said anything
+ * and the suite would have stayed green.
+ *
+ * THE EXPECTATION IS DERIVED FROM `DATA_PORTAL_URL`, NOT FROM A LIST.
+ *
+ * The table below holds two portals. Each run configures the server for one of
+ * them, and the *other* row supplies the vocabulary that must not appear. A
+ * guard exercised only under the default configuration is the shape that cannot
+ * fail, so both rows are driven, and each run also asserts positively that the
+ * configured domain does reach the surface — proving the text adapts rather
+ * than merely having been scrubbed of city names.
+ *
+ * IT ALSO REQUIRES THE TEXT TO BE RESOLVED LAZILY. One server instance answers
+ * under both configurations. That is not incidental: `src/index.ts` calls
+ * `dotenv.config()` in its module body, which runs *after* every import it
+ * makes, so anything that snapshots `DATA_PORTAL_URL` at module-load time reads
+ * the environment before dotenv has populated it. Lazy resolution is the only
+ * correct shape here, and this test fails if it is lost.
+ *
+ * STATED BLIND SPOTS.
+ *
+ * 1. The `skill-guidance` prompt body is excluded from the foreign-vocabulary
+ *    assertion. Its text comes from `src/skills/*.ts`, which are GENERATED from
+ *    `civic-ai-tools/docs/skills/*.md` and are never hand-edited here (see
+ *    `.claude/rules/skills.md`). Those documents name several cities on
+ *    purpose: they describe multi-portal capability ("NYC, Chicago, SF, Seattle,
+ *    LA, and other Socrata portals"), not a default this server would be wrong
+ *    about. Changing them is a PR to the hub repository, not to this one.
+ * 2. It walks string *values*, not object keys.
+ * 3. `tools/call` responses are not covered — those carry portal data, not
+ *    advertised text.
+ */
+
+import { describe, it, expect, afterAll, beforeAll } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createServer } from '../index.js';
+
+type PortalFixture = {
+  /** What `DATA_PORTAL_URL` is set to for this run. */
+  url: string;
+  /** The bare host the server should be talking about. */
+  domain: string;
+  /**
+   * Words that identify this portal's city and belong to no other row in the
+   * table. When the server is configured for the *other* row, none of these may
+   * appear in anything it sends.
+   */
+  vocabulary: string[];
+};
+
+const PORTALS: PortalFixture[] = [
+  {
+    url: 'https://data.cityofnewyork.us',
+    domain: 'data.cityofnewyork.us',
+    vocabulary: ['NYC', 'New York', 'cityofnewyork', 'NYPD', 'borough', 'Manhattan']
+  },
+  {
+    url: 'https://data.cityofchicago.org',
+    domain: 'data.cityofchicago.org',
+    vocabulary: ['Chicago', 'cityofchicago', 'Illinois', 'Cook County']
+  }
+];
+
+/**
+ * Hostnames that legitimately appear in advertised text and are not the
+ * configured portal. Empty on purpose: nothing today needs an exemption, and an
+ * entry added here has to be justified in review.
+ */
+const NON_PORTAL_HOSTS: string[] = [];
+
+/** A host-shaped token, restricted to TLDs an open-data portal actually uses. */
+const HOST_PATTERN = /\b(?:[a-z0-9-]+\.)+(?:us|org|gov|com|io|net|edu)\b/gi;
+
+/** Every string value reachable in a response, tagged with where it came from. */
+function collectStrings(value: unknown, path: string, out: Array<{ path: string; text: string }>): void {
+  if (typeof value === 'string') {
+    out.push({ path, text: value });
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item, i) => collectStrings(item, `${path}[${i}]`, out));
+    return;
+  }
+  if (value && typeof value === 'object') {
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      collectStrings(child, `${path}.${key}`, out);
+    }
+  }
+}
+
+type Surface = { label: string; response: unknown };
+
+/**
+ * Drives every advertised surface and returns what came back over the wire.
+ * `skill-guidance` is fetched too, but returned separately so the stated
+ * carve-out is visible rather than silently applied.
+ */
+async function readAdvertisedSurfaces(client: Client): Promise<{
+  surfaces: Surface[];
+  skillGuidance: unknown;
+}> {
+  const surfaces: Surface[] = [];
+
+  const toolsList = await client.listTools();
+  surfaces.push({ label: 'tools/list', response: toolsList });
+
+  const promptsList = await client.listPrompts();
+  surfaces.push({ label: 'prompts/list', response: promptsList });
+
+  const resourcesList = await client.listResources();
+  surfaces.push({ label: 'resources/list', response: resourcesList });
+
+  let skillGuidance: unknown = null;
+  for (const prompt of promptsList.prompts) {
+    // Supply every declared argument so no body falls back to a default branch.
+    const args: Record<string, string> = {};
+    for (const argument of prompt.arguments ?? []) {
+      args[argument.name] = `sample ${argument.name}`;
+    }
+    const got = await client.getPrompt({ name: prompt.name, arguments: args });
+    if (prompt.name === 'skill-guidance') {
+      skillGuidance = got;
+    } else {
+      surfaces.push({ label: `prompts/get(${prompt.name})`, response: got });
+    }
+  }
+
+  // And again with no arguments at all, so the default-value branches — which
+  // is where a hardcoded city hides most easily — are driven too.
+  for (const prompt of promptsList.prompts) {
+    if (prompt.name === 'skill-guidance') continue;
+    if ((prompt.arguments ?? []).some((a) => a.required)) continue;
+    const got = await client.getPrompt({ name: prompt.name });
+    surfaces.push({ label: `prompts/get(${prompt.name}, defaults)`, response: got });
+  }
+
+  for (const resource of resourcesList.resources) {
+    const got = await client.readResource({ uri: resource.uri });
+    surfaces.push({ label: `resources/read(${resource.uri})`, response: got });
+  }
+
+  expect(surfaces.length).toBeGreaterThan(5);
+  return { surfaces, skillGuidance };
+}
+
+describe('advertised text describes the configured portal', () => {
+  let client: Client;
+  let close: () => Promise<void>;
+  const originalPortalUrl = process.env.DATA_PORTAL_URL;
+
+  beforeAll(async () => {
+    const server = await createServer();
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    client = new Client({ name: 'portal-text-guard', version: '1.0.0' }, { capabilities: {} });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    close = async () => {
+      await client.close();
+      await server.close();
+    };
+  });
+
+  afterAll(async () => {
+    await close?.();
+    if (originalPortalUrl === undefined) {
+      delete process.env.DATA_PORTAL_URL;
+    } else {
+      process.env.DATA_PORTAL_URL = originalPortalUrl;
+    }
+  });
+
+  for (const [index, portal] of PORTALS.entries()) {
+    const others = PORTALS.filter((_, i) => i !== index);
+
+    describe(`configured for ${portal.domain}`, () => {
+      let surfaces: Surface[];
+      let skillGuidance: unknown;
+
+      beforeAll(async () => {
+        process.env.DATA_PORTAL_URL = portal.url;
+        ({ surfaces, skillGuidance } = await readAdvertisedSurfaces(client));
+      });
+
+      it('names no other portal’s city anywhere in what it sends', () => {
+        const offences: string[] = [];
+        for (const surface of surfaces) {
+          const strings: Array<{ path: string; text: string }> = [];
+          collectStrings(surface.response, surface.label, strings);
+          for (const { path, text } of strings) {
+            for (const other of others) {
+              for (const word of other.vocabulary) {
+                if (text.toLowerCase().includes(word.toLowerCase())) {
+                  offences.push(`${path}: "${word}" in ${JSON.stringify(text.slice(0, 160))}`);
+                }
+              }
+            }
+          }
+        }
+        expect(offences, `configured for ${portal.domain}, but:\n${offences.join('\n')}`).toEqual([]);
+      });
+
+      it('spells no portal host other than the configured one', () => {
+        const offences: string[] = [];
+        for (const surface of surfaces) {
+          const strings: Array<{ path: string; text: string }> = [];
+          collectStrings(surface.response, surface.label, strings);
+          for (const { path, text } of strings) {
+            for (const host of text.match(HOST_PATTERN) ?? []) {
+              const found = host.toLowerCase();
+              if (found === portal.domain.toLowerCase()) continue;
+              if (NON_PORTAL_HOSTS.includes(found)) continue;
+              offences.push(`${path}: "${host}" in ${JSON.stringify(text.slice(0, 160))}`);
+            }
+          }
+        }
+        expect(offences, `configured for ${portal.domain}, but:\n${offences.join('\n')}`).toEqual([]);
+      });
+
+      it('says which portal it is configured for on every surface a model reads', () => {
+        const missing: string[] = [];
+        // tools/list, every prompt body and the two prose resources have to name
+        // the portal — scrubbing the city out without naming the real one would
+        // otherwise pass the two assertions above.
+        for (const surface of surfaces) {
+          const isPromptBody = surface.label.startsWith('prompts/get');
+          const isToolsList = surface.label === 'tools/list';
+          const isProseResource =
+            surface.label.startsWith('resources/read') && !surface.label.includes('popular');
+          if (!isPromptBody && !isToolsList && !isProseResource) continue;
+
+          const strings: Array<{ path: string; text: string }> = [];
+          collectStrings(surface.response, surface.label, strings);
+          const namesPortal = strings.some(({ text }) =>
+            text.toLowerCase().includes(portal.domain.toLowerCase())
+          );
+          if (!namesPortal) missing.push(surface.label);
+        }
+        expect(missing, `no mention of ${portal.domain} in:\n${missing.join('\n')}`).toEqual([]);
+      });
+
+      it('still serves the skill-guidance prompt (excluded from the assertions above)', () => {
+        // Stated carve-out, not a silent one: the body is generated from the hub
+        // repository's skill documents, which name several cities on purpose.
+        expect(skillGuidance).toBeTruthy();
+      });
+    });
+  }
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ import express from 'express';
 import dotenv from 'dotenv';
 import cors from 'cors';
 import crypto from 'crypto';
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import {
   UNIFIED_SOCRATA_TOOL,
   SEARCH_TOOL,
@@ -40,7 +42,16 @@ import { composeSkillGuidance } from './skills/compose.js';
 
 dotenv.config();
 
-async function createServer(transport?: OpenAICompatibleTransport): Promise<Server> {
+/**
+ * Builds a Server with every tool/prompt/resource handler registered.
+ *
+ * Exported so a test can drive the real handlers over an in-memory transport
+ * rather than rebuilding a look-alike server of its own. Before this export
+ * existed, every "integration" test in `src/__tests__` constructed its own
+ * `McpServer` with its own titles and descriptions, so nothing in the suite
+ * ever read what this file actually returns.
+ */
+export async function createServer(transport?: OpenAICompatibleTransport): Promise<Server> {
   console.error('[Server] Creating Server instance...');
   
   const server = new Server(
@@ -1230,22 +1241,45 @@ async function startApp() {
   }
 }
 
-// Check for --stdio flag to determine transport mode
-if (process.argv.includes('--stdio')) {
-  // Stdio mode for Claude Code / Cursor
-  (async () => {
-    try {
-      console.error('[Startup] Starting in stdio mode...');
-      const transport = new StdioServerTransport();
-      const server = await createServer();
-      await server.connect(transport);
-      console.error('[Startup] Server connected to stdio transport');
-    } catch (error) {
-      console.error('[Fatal] Error starting stdio server:', error);
-      process.exit(1);
-    }
-  })();
-} else {
-  // HTTP mode for hosted deployments (the reference deployment runs on Render)
-  startApp().catch(console.error);
+/**
+ * True unless this module is being imported by some other entry point.
+ *
+ * `createServer` is exported for tests, and importing this module used to boot
+ * a transport as a side effect. The check is deliberately biased towards
+ * starting: it returns true whenever the answer cannot be established (no
+ * `argv[1]`, an unresolvable path), so `npm run start`, the `--stdio` bin entry
+ * and the Render start command keep the behaviour they had. `realpathSync` on
+ * both sides is what makes the npx/`node_modules/.bin` symlink resolve to the
+ * same file as `import.meta.url`.
+ */
+function isProcessEntrypoint(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return true;
+  try {
+    return realpathSync(entry) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return true;
+  }
+}
+
+if (isProcessEntrypoint()) {
+  // Check for --stdio flag to determine transport mode
+  if (process.argv.includes('--stdio')) {
+    // Stdio mode for Claude Code / Cursor
+    (async () => {
+      try {
+        console.error('[Startup] Starting in stdio mode...');
+        const transport = new StdioServerTransport();
+        const server = await createServer();
+        await server.connect(transport);
+        console.error('[Startup] Server connected to stdio transport');
+      } catch (error) {
+        console.error('[Fatal] Error starting stdio server:', error);
+        process.exit(1);
+      }
+    })();
+  } else {
+    // HTTP mode for hosted deployments (the reference deployment runs on Render)
+    startApp().catch(console.error);
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { McpError, ErrorCode } from './utils/mcp-errors.js';
 import { composeSkillGuidance } from './skills/compose.js';
+import { getDefaultDomain } from './utils/portal-config.js';
 
 // NOTE(#47): the prompts/resources request schemas were previously hand-rolled
 // here behind a comment claiming they were "not properly exported from SDK".
@@ -41,6 +42,34 @@ import { composeSkillGuidance } from './skills/compose.js';
 // removed. Import the SDK's own schemas instead.
 
 dotenv.config();
+
+/**
+ * Advertised identifiers that used to name one city.
+ *
+ * These are the names and URIs a client addresses, not prose, so they are
+ * versioned rather than interpolated: a URI that changed with `DATA_PORTAL_URL`
+ * would not be an identifier at all. The pre-rename forms are still accepted so
+ * a client that hardcoded one keeps working; they are simply never advertised.
+ * Measured before renaming: nothing in this repository, the hub repository or
+ * the website addresses them — the only consumers were this file.
+ */
+const RESOURCE_URIS = {
+  portalOverview: 'data://portal/info/portal-overview',
+  popularDatasets: 'data://portal/info/popular-datasets',
+  apiGuide: 'data://portal/info/api-guide'
+} as const;
+
+const LEGACY_RESOURCE_URI_PREFIX = 'data://nyc/info/';
+
+/** Maps a pre-rename resource URI onto its current one; passes anything else through. */
+function resolveResourceUri(uri: string): string {
+  return uri.startsWith(LEGACY_RESOURCE_URI_PREFIX)
+    ? `data://portal/info/${uri.slice(LEGACY_RESOURCE_URI_PREFIX.length)}`
+    : uri;
+}
+
+const ANALYZE_PROMPT = 'analyze_open_data';
+const ANALYZE_PROMPT_LEGACY_NAME = 'analyze_nyc_data';
 
 /**
  * Builds a Server with every tool/prompt/resource handler registered.
@@ -190,13 +219,16 @@ export async function createServer(transport?: OpenAICompatibleTransport): Promi
       },
       {
         name: 'search',
-        title: 'Search NYC Open Data',
+        // Read the title from the tool definition rather than re-declaring it.
+        // Two literals here named a portal this server may not be serving, and
+        // they could drift from socrata-tools.ts without anything noticing.
+        title: SEARCH_TOOL.title,
         description: SEARCH_TOOL.description,
         inputSchema: SEARCH_TOOL.inputSchema
       },
       {
         name: 'fetch',
-        title: 'Fetch NYC Data Document',
+        title: FETCH_TOOL.title,
         description: FETCH_TOOL.description,
         inputSchema: FETCH_TOOL.inputSchema
       }
@@ -211,11 +243,13 @@ export async function createServer(transport?: OpenAICompatibleTransport): Promi
   server.setRequestHandler(ListPromptsRequestSchema, async (request) => {
     console.error('[Server - ListPrompts] Request received');
     
+    const portalDomain = getDefaultDomain();
+
     const prompts = [
       {
-        name: 'analyze_nyc_data',
-        title: 'Analyze NYC Open Data',
-        description: 'Search and analyze datasets from NYC Open Data portal',
+        name: ANALYZE_PROMPT,
+        title: 'Analyze Open Data',
+        description: `Search and analyze datasets from the open data portal this server is configured for (${portalDomain})`,
         arguments: [
           {
             name: 'topic',
@@ -231,8 +265,8 @@ export async function createServer(transport?: OpenAICompatibleTransport): Promi
       },
       {
         name: 'find_dataset',
-        title: 'Find NYC Dataset',
-        description: 'Help find specific datasets in the NYC Open Data portal',
+        title: 'Find a Dataset',
+        description: `Help find specific datasets on the open data portal this server is configured for (${portalDomain})`,
         arguments: [
           {
             name: 'description',
@@ -243,8 +277,8 @@ export async function createServer(transport?: OpenAICompatibleTransport): Promi
       },
       {
         name: 'compare_neighborhoods',
-        title: 'Compare NYC Neighborhoods',
-        description: 'Compare data across different NYC neighborhoods or boroughs',
+        title: 'Compare Neighborhoods',
+        description: `Compare data across neighborhoods or districts on the open data portal this server is configured for (${portalDomain})`,
         arguments: [
           {
             name: 'metric',
@@ -253,7 +287,9 @@ export async function createServer(transport?: OpenAICompatibleTransport): Promi
           },
           {
             name: 'neighborhoods',
-            description: 'Which neighborhoods or boroughs to compare (comma-separated)',
+            // "boroughs" is one city's subdivision vocabulary; whatever this
+            // portal calls its areas is the caller's to supply.
+            description: 'Which neighborhoods or districts to compare (comma-separated)',
             required: true
           }
         ]
@@ -308,17 +344,18 @@ export async function createServer(transport?: OpenAICompatibleTransport): Promi
       };
     }
 
-    if (promptName === 'analyze_nyc_data') {
-      const topic = args?.topic || 'general NYC data';
+    if (promptName === ANALYZE_PROMPT || promptName === ANALYZE_PROMPT_LEGACY_NAME) {
+      const portalDomain = getDefaultDomain();
+      const topic = args?.topic || 'general open data';
       const timePeriod = args?.time_period ? ` for ${args.time_period}` : '';
       return {
-        description: `Analyze ${topic} from NYC Open Data`,
+        description: `Analyze ${topic} from ${portalDomain}`,
         messages: [
           {
             role: 'user' as const,
             content: {
               type: 'text' as const,
-              text: `Search and analyze datasets about "${topic}"${timePeriod} from the NYC Open Data portal (data.cityofnewyork.us). Use the get_data tool to discover relevant datasets and run SoQL queries. Provide key findings with data tables and methodology.`
+              text: `Search and analyze datasets about "${topic}"${timePeriod} on the open data portal this server is configured for (${portalDomain}). Use the get_data tool to discover relevant datasets and run SoQL queries. Provide key findings with data tables and methodology.`
             }
           }
         ]
@@ -326,15 +363,16 @@ export async function createServer(transport?: OpenAICompatibleTransport): Promi
     }
 
     if (promptName === 'find_dataset') {
+      const portalDomain = getDefaultDomain();
       const description = args?.description || 'data';
       return {
-        description: `Find NYC datasets matching: ${description}`,
+        description: `Find datasets on ${portalDomain} matching: ${description}`,
         messages: [
           {
             role: 'user' as const,
             content: {
               type: 'text' as const,
-              text: `Help me find datasets on the NYC Open Data portal (data.cityofnewyork.us) that match this description: "${description}". Use the search tool to find relevant datasets and provide their names, IDs, and descriptions.`
+              text: `Help me find datasets on the open data portal this server is configured for (${portalDomain}) that match this description: "${description}". Use the search tool to find relevant datasets and provide their names, IDs, and descriptions.`
             }
           }
         ]
@@ -342,8 +380,9 @@ export async function createServer(transport?: OpenAICompatibleTransport): Promi
     }
 
     if (promptName === 'compare_neighborhoods') {
+      const portalDomain = getDefaultDomain();
       const metric = args?.metric || 'data';
-      const neighborhoods = args?.neighborhoods || 'all boroughs';
+      const neighborhoods = args?.neighborhoods || 'all areas the portal reports on';
       return {
         description: `Compare ${metric} across ${neighborhoods}`,
         messages: [
@@ -351,7 +390,7 @@ export async function createServer(transport?: OpenAICompatibleTransport): Promi
             role: 'user' as const,
             content: {
               type: 'text' as const,
-              text: `Compare ${metric} across these NYC neighborhoods/boroughs: ${neighborhoods}. Use the NYC Open Data portal to find relevant datasets and run comparative queries. Present findings in a comparison table.`
+              text: `Compare ${metric} across these neighborhoods or districts: ${neighborhoods}. Use the open data portal this server is configured for (${portalDomain}) to find relevant datasets and run comparative queries. Present findings in a comparison table.`
             }
           }
         ]
@@ -365,26 +404,31 @@ export async function createServer(transport?: OpenAICompatibleTransport): Promi
   server.setRequestHandler(ListResourcesRequestSchema, async (request) => {
     console.error('[Server - ListResources] Request received');
     
+    const portalDomain = getDefaultDomain();
+
     const resources = [
       {
-        uri: 'data://nyc/info/portal-overview',
-        name: 'NYC Open Data Portal Overview',
-        title: 'NYC Open Data Portal Information',
-        description: 'Basic information about NYC Open Data portal and available datasets',
+        uri: RESOURCE_URIS.portalOverview,
+        name: 'Open Data Portal Overview',
+        title: `${portalDomain} Portal Overview`,
+        description: `What the portal this server is configured for (${portalDomain}) offers, and how to explore it from here`,
         mimeType: 'text/plain'
       },
       {
-        uri: 'data://nyc/info/popular-datasets',
-        name: 'Popular NYC Datasets',
-        title: 'Most Popular NYC Open Data Datasets',
-        description: 'List of the most frequently accessed datasets on NYC Open Data',
-        mimeType: 'application/json'
+        uri: RESOURCE_URIS.popularDatasets,
+        name: 'Finding Popular Datasets',
+        title: `How to Find Popular Datasets on ${portalDomain}`,
+        // Was a hardcoded list of five datasets from one city, which is false on
+        // any other portal and goes stale on that one. What is actually popular
+        // is a property of the portal, so this resource says how to ask it.
+        description: `How to find the most-used datasets on the portal this server is configured for (${portalDomain})`,
+        mimeType: 'text/markdown'
       },
       {
-        uri: 'data://nyc/info/api-guide',
+        uri: RESOURCE_URIS.apiGuide,
         name: 'Socrata API Guide',
         title: 'Quick Guide to Socrata API',
-        description: 'Quick reference for using Socrata API with NYC Open Data',
+        description: `Quick reference for using the Socrata API against ${portalDomain}`,
         mimeType: 'text/markdown'
       }
     ];
@@ -401,85 +445,79 @@ export async function createServer(transport?: OpenAICompatibleTransport): Promi
   server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
     console.error('[Server - ReadResource] Request received for URI:', request.params.uri);
     
+    const portalDomain = getDefaultDomain();
+
     const resourceContents: Record<string, any> = {
-      'data://nyc/info/portal-overview': {
-        uri: 'data://nyc/info/portal-overview',
-        name: 'NYC Open Data Portal Overview',
+      [RESOURCE_URIS.portalOverview]: {
+        uri: RESOURCE_URIS.portalOverview,
+        name: 'Open Data Portal Overview',
         mimeType: 'text/plain',
-        text: `NYC Open Data Portal Overview
+        // The dataset count, the publishing agencies and the category list this
+        // text used to assert were one city's, stated as fact. What a portal
+        // holds is the portal's property; ask it rather than assert it.
+        text: `Open Data Portal Overview
 
-The NYC Open Data portal (data.cityofnewyork.us) provides access to thousands of datasets from New York City agencies.
+This server is configured for the Socrata open data portal at ${portalDomain}.
+Any tool call that does not pass an explicit "domain" argument runs against
+that portal.
 
-Key Information:
-- Over 3,000+ datasets available
-- Updated regularly by city agencies
-- Free to access and use
-- Powered by Socrata platform
-- Supports various data formats (CSV, JSON, GeoJSON, etc.)
+What a Socrata portal provides:
+- A catalog of datasets published by the organizations behind the portal
+- Dataset metadata (columns, types, update cadence) alongside the records
+- Free, key-less read access over the Socrata API
+- Several response formats on the underlying API (JSON, CSV, GeoJSON)
 
-Common Dataset Categories:
-- Public Safety (crime data, fire incidents, etc.)
-- Transportation (traffic, parking, transit)
-- Health (restaurant inspections, health statistics)
-- Housing & Development (building permits, violations)
-- Environment (air quality, tree census)
-- Education (school performance, enrollment)
-- Finance (budget, spending)
+How to explore it from here:
+- search — full-text search over the catalog; returns dataset IDs
+- fetch — retrieve a dataset's metadata, or a record, by identifier
+- get_data with type "catalog" — browse or filter the catalog
+- get_data with type "metadata" — inspect one dataset's columns
+- get_data with type "query" — run a SoQL query against a dataset
+- get_data with type "metrics" — usage metrics for a dataset
 
-Access Methods:
-- Web interface for browsing and filtering
-- Socrata API for programmatic access
-- Direct download in multiple formats
-- Real-time data feeds for some datasets`
+Which datasets exist on ${portalDomain}, how many there are, and which
+organizations publish them are properties of that portal. Ask it with search or
+the catalog rather than assuming a list.`
       },
-      'data://nyc/info/popular-datasets': {
-        uri: 'data://nyc/info/popular-datasets',
-        name: 'Popular NYC Datasets',
-        mimeType: 'application/json',
-        text: JSON.stringify({
-          popular_datasets: [
-            {
-              name: "311 Service Requests",
-              id: "erm2-nwe9",
-              description: "All 311 Service Requests from 2010 to present",
-              category: "Public Services"
-            },
-            {
-              name: "NYC Restaurant Inspection Results",
-              id: "43nn-pn8j",
-              description: "Restaurant inspection results including letter grades",
-              category: "Health"
-            },
-            {
-              name: "Motor Vehicle Collisions - Crashes",
-              id: "h9gi-nx95",
-              description: "Motor vehicle collision data from NYPD",
-              category: "Public Safety"
-            },
-            {
-              name: "DOB Job Application Filings",
-              id: "ic3t-wcy2",
-              description: "Building permit applications filed with DOB",
-              category: "Housing & Development"
-            },
-            {
-              name: "NYPD Complaint Data Current (Year To Date)",
-              id: "5uac-w243",
-              description: "NYPD complaint data for current year",
-              category: "Public Safety"
-            }
-          ]
-        }, null, 2)
+      [RESOURCE_URIS.popularDatasets]: {
+        uri: RESOURCE_URIS.popularDatasets,
+        name: 'Finding Popular Datasets',
+        mimeType: 'text/markdown',
+        // This was a hardcoded snapshot of five datasets from one city, served
+        // as application/json under a title naming that city's portal. It could
+        // not be made true for another portal by interpolating a domain: the
+        // dataset IDs, the names and the publishing agencies were all one
+        // portal's. Deriving the list live from the catalog would put a network
+        // call inside resources/read and a new failure mode with it, so the
+        // resource now answers the same question by pointing at the tools that
+        // can actually answer it. Making it live is a follow-up, not a text fix.
+        text: `# Finding the most-used datasets on ${portalDomain}
+
+This server ships no curated list of popular datasets. Which datasets are most
+used is a property of ${portalDomain} and it changes over time, so a list baked
+into the server would go stale here and would be wrong on any other portal.
+
+Ask the portal instead:
+
+- \`get_data\` with \`type: "catalog"\` and a \`query\` returns catalog entries
+  matching a search phrase, most relevant first.
+- \`get_data\` with \`type: "metrics"\` and a \`dataset_id\` returns that
+  dataset's usage metrics.
+- \`search\` returns dataset IDs for a full-text query; \`fetch\` retrieves one
+  by identifier.
+
+A reasonable sequence: \`search\` for the topic, then \`get_data\` with
+\`type: "metrics"\` on the candidates to compare how heavily each is used.`
       },
-      'data://nyc/info/api-guide': {
-        uri: 'data://nyc/info/api-guide',
+      [RESOURCE_URIS.apiGuide]: {
+        uri: RESOURCE_URIS.apiGuide,
         name: 'Socrata API Guide',
         mimeType: 'text/markdown',
         text: `# Socrata API Quick Guide
 
 ## Basic API Structure
 \`\`\`
-https://data.cityofnewyork.us/resource/{dataset-id}.{format}
+https://${portalDomain}/resource/{dataset-id}.{format}
 \`\`\`
 
 ## Common Parameters
@@ -499,7 +537,7 @@ https://data.cityofnewyork.us/resource/{dataset-id}.{format}
 
 ### Filter with WHERE clause
 \`\`\`
-/resource/dataset-id.json?$where=borough='MANHATTAN' AND year=2023
+/resource/dataset-id.json?$where=status='Open' AND year=2023
 \`\`\`
 
 ### Full-text search
@@ -525,11 +563,11 @@ https://data.cityofnewyork.us/resource/{dataset-id}.{format}
       }
     };
     
-    const content = resourceContents[request.params.uri];
+    const content = resourceContents[resolveResourceUri(request.params.uri)];
     if (!content) {
       throw new Error(`Resource not found: ${request.params.uri}`);
     }
-    
+
     console.error('[Server - ReadResource] Returning content for:', request.params.uri);
     
     return {

--- a/src/tools/socrata-tools.ts
+++ b/src/tools/socrata-tools.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { type JsonSchema7Type } from 'zod-to-json-schema'; // Keep for typing if manually constructing
 import { Tool } from '@modelcontextprotocol/sdk/types.js'; // Suffix needed
 import { McpError, ErrorCode } from '../utils/mcp-errors.js';
+import { getDefaultDomain } from '../utils/portal-config.js';
 import {
   fetchFromSocrataApi,
   DatasetMetadata,
@@ -25,11 +26,9 @@ export type ToolWithHandler = Tool & {
   handler: (params: Record<string, unknown>) => Promise<unknown>;
 };
 
-// Get the default domain from environment
-const getDefaultDomain = () => {
-  const url = process.env.DATA_PORTAL_URL || 'https://data.cityofnewyork.us';
-  return url.replace(/^https?:\/\//, '');
-};
+// The configured portal's host. One implementation, in ../utils/portal-config.js,
+// so src/index.ts resolves the same value instead of naming a portal in literal
+// text (server#61).
 
 // Handler for catalog functionality
 async function handleCatalog(params: {
@@ -323,7 +322,10 @@ export const socrataToolZodSchema = z.object({
   query: z.string().min(1).optional()
          .describe('General search phrase OR a full SoQL query string. If this is a full SoQL query (e.g., starts with SELECT), other SoQL parameters like select, where, q might be overridden or ignored by the handler in favor of the full SoQL query. If it\'s a search phrase, it will likely be used for a full-text search ($q parameter to Socrata).'),
   // Optional parameters - these should also be in jsonParameters if they are to be exposed to the client
-  domain: z.string().optional().describe('The Socrata domain (e.g., data.cityofnewyork.us)'),
+  // No portal example here: this schema is used only to parse incoming
+  // arguments, never advertised, so it must not carry a domain snapshotted at
+  // module-load time. The advertised copy is jsonParameters.properties.domain.
+  domain: z.string().optional().describe('The Socrata domain to query; defaults to the portal this server is configured for'),
   portal: z.string().optional().describe('Alias for domain — the Socrata portal domain'),
   limit: z.union([z.coerce.number().int().positive(), z.literal('all')]).optional().describe('Number of results to return, or "all" to fetch all available data up to configured cap'),
   offset: z.number().int().nonnegative().optional().describe('Offset for pagination'),
@@ -358,7 +360,12 @@ const jsonParameters: any = {
     // Optional parameters reflected from socrataToolZodSchema
     domain: {
       type: 'string',
-      description: 'The Socrata domain (e.g., data.cityofnewyork.us)'
+      // A getter for the same reason SEARCH_TOOL's description is one: this
+      // object is serialized into tools/list on every request, and the example
+      // has to be the portal this server is actually configured for.
+      get description() {
+        return `The Socrata domain to query; defaults to the portal this server is configured for (${getDefaultDomain()})`;
+      }
     },
     portal: {
       type: 'string',
@@ -439,11 +446,19 @@ export const UNIFIED_SOCRATA_TOOL: ToolWithHandler = {
   handler: handleSocrataTool as (params: Record<string, unknown>) => Promise<unknown>
 };
 
-// New search tool that returns only id/score pairs
+// New search tool that returns only id/score pairs.
+// `title` and `description` are getters, not literals: the handler behind them
+// resolves the portal from DATA_PORTAL_URL at call time, so the text a model
+// reads has to resolve it at read time too. A literal built at module load
+// would also read the environment before src/index.ts runs dotenv.config().
 export const SEARCH_TOOL: ToolWithHandler = {
   name: 'search',
-  title: 'Search NYC Open Data',
-  description: 'Search NYC Open Data portal and return matching dataset IDs',
+  get title() {
+    return `Search ${getDefaultDomain()}`;
+  },
+  get description() {
+    return `Search the open data portal this server is configured for (${getDefaultDomain()}) and return matching dataset IDs`;
+  },
   inputSchema: searchJsonParameters,  // Latest MCP spec uses 'inputSchema'
   handler: handleSearchTool as (params: Record<string, unknown>) => Promise<unknown>
 };
@@ -451,8 +466,12 @@ export const SEARCH_TOOL: ToolWithHandler = {
 // New document retrieval tool
 export const FETCH_TOOL: ToolWithHandler = {
   name: 'fetch',
-  title: 'Fetch NYC Data Document',
-  description: 'Retrieve full dataset metadata or record content from NYC Open Data portal',
+  get title() {
+    return `Fetch Document from ${getDefaultDomain()}`;
+  },
+  get description() {
+    return `Retrieve full dataset metadata or record content from the open data portal this server is configured for (${getDefaultDomain()})`;
+  },
   inputSchema: fetchJsonParameters,
   handler: handleFetchTool as (params: Record<string, unknown>) => Promise<unknown>
 };

--- a/src/utils/portal-config.ts
+++ b/src/utils/portal-config.ts
@@ -1,0 +1,39 @@
+/**
+ * One resolver for "the portal this server is configured for".
+ *
+ * This used to be a module-local arrow function in `src/tools/socrata-tools.ts`,
+ * which meant `src/index.ts` could not reach it and re-declared the portal's
+ * name as literal text instead (server#61). It lives here rather than in
+ * `portal-info.ts` because that module pulls in axios and fetches the portal
+ * homepage; this one is pure and reads only the environment, so anything that
+ * needs to *name* the portal can import it without taking a network dependency.
+ *
+ * ALWAYS CALL IT, NEVER SNAPSHOT IT. `src/index.ts` calls `dotenv.config()` in
+ * its module body, which runs after every import that module makes. A caller
+ * that resolves the domain at module-load time therefore reads the environment
+ * before dotenv has populated it. Callers that need the domain inside a string
+ * expose that string through a getter or build it per request.
+ */
+
+/**
+ * The portal used when `DATA_PORTAL_URL` is unset.
+ *
+ * This is a code default naming one deployment, and it is inconsistent with the
+ * rest of the tree: `src/utils/portal-info.ts` throws `DATA_PORTAL_URL must be
+ * set`, `src/utils/api.ts` throws `DATA_PORTAL_URL is not configured`, and
+ * `CLAUDE.md` documents the variable as required. Removing it would change
+ * bring-up behaviour — tool calls that silently work today would start
+ * throwing — so it is named and left in place here rather than dropped as a
+ * side effect of a text change. See the phase report on Wave N10 P-S1.
+ */
+export const FALLBACK_PORTAL_URL = 'https://data.cityofnewyork.us';
+
+/**
+ * The bare host of the configured portal, e.g. `data.cityofchicago.org`.
+ * Every default `domain` a handler uses, and every advertised string that names
+ * the portal, resolves through this function.
+ */
+export function getDefaultDomain(): string {
+  const url = process.env.DATA_PORTAL_URL || FALLBACK_PORTAL_URL;
+  return url.replace(/^https?:\/\//, '');
+}


### PR DESCRIPTION
Wave N10 phase P-S1 of sprint anchor npstorey/civic-ai-tools-website#409. Closes #61, widened by the owner's scope ruling from the four literals the issue named to the whole class.

## The property

The text this server sends a client or a model must describe the portal it is actually configured for, and must not name a city it may not be serving. The server resolves its portal at runtime from `DATA_PORTAL_URL`; its advertised strings were hardcoded to one city.

This is civic-ai-tools-website#323's lesson one repository over: a guard names the property, not the constant the issue named.

## Branch and blast zone

Branch `sprint-409/ps1-tool-text-says-what-the-server-does`, cut from `origin/main` at `c207f55`.

```
 src/__tests__/portal-text.test.ts | 297 +++++++++++++++++++++++++++++++++++++
 src/index.ts                      | 304 +++++++++++++++++++++++---------------
 src/tools/socrata-tools.ts        |  43 ++++--
 src/utils/portal-config.ts        |  39 +++++
 4 files changed, 555 insertions(+), 128 deletions(-)
```

Inside the declared zone: `src/index.ts`, `src/tools/socrata-tools.ts`, one new shared config module, and one new test. Nothing else touched — `src/skills/*.ts` untouched (generated; see below), no sibling repository touched, no version bump, no tag, no deploy.

## Two commits, red then green

**`dbd5232` — the guard, red.** It drives the real `createServer()` from `src/index.ts` over an in-memory transport with a real MCP `Client`, and asserts over the JSON-RPC responses that come back from `tools/list`, `prompts/list`, `prompts/get` (every prompt, with arguments and again with defaults), `resources/list` and `resources/read` (every resource). It never reads a constant under test back into its own expectation.

The expectation is derived from `DATA_PORTAL_URL`. A two-row portal table is driven in turn, and each row's vocabulary is the *other* row's negative — so the guard is exercised under a second configuration by construction, not as an afterthought.

This commit also carries the minimum needed to make that possible, and it is disclosed rather than folded in: `createServer` was not exported, and importing `src/index.ts` booted a transport as a side effect. It is now exported, and the auto-start dispatch is gated on an entry-point check biased towards starting (`realpathSync` on both sides; returns true whenever the answer cannot be established). Without this the red would have been an import error rather than a statement about strings.

**`0a7f6a4` — the fix.** Green under both configurations.

## Evidence

### The red, pre-fix, at `c207f55` + the export enabler

Under the default (New York) configuration, only the positive assertion fails — the foreign-vocabulary and host assertions are green, which is precisely the shape that cannot fail:

```
 FAIL  portal-text.test.ts > configured for data.cityofnewyork.us > says which portal it is configured for on every surface a model reads
AssertionError: no mention of data.cityofnewyork.us in:
prompts/get(compare_neighborhoods)
```

Under the second configuration, 43 offences across every surface. An excerpt:

```
 FAIL  portal-text.test.ts > configured for data.cityofchicago.org > names no other portal's city anywhere in what it sends
AssertionError: configured for data.cityofchicago.org, but:
tools/list.tools[0].inputSchema.properties.domain.description: "cityofnewyork" in "The Socrata domain (e.g., data.cityofnewyork.us)"
tools/list.tools[1].title: "NYC" in "Search NYC Open Data"
tools/list.tools[1].description: "NYC" in "Search NYC Open Data portal and return matching dataset IDs"
tools/list.tools[2].title: "NYC" in "Fetch NYC Data Document"
tools/list.tools[2].description: "NYC" in "Retrieve full dataset metadata or record content from NYC Open Data portal"
prompts/list.prompts[0].name: "NYC" in "analyze_nyc_data"
...
prompts/get(analyze_nyc_data).messages[0].content.text: "cityofnewyork" in "Search and analyze datasets about ... from the NYC Open Data portal (data.cityofnewyork.us)."
resources/read(data://nyc/info/popular-datasets).contents[0].text: "NYPD" in "{ \"popular_datasets\": [ ... }"
resources/read(data://nyc/info/api-guide).contents[0].text: "Manhattan" in "# Socrata API Quick Guide ..."
: expected [ …(43) ] to deeply equal []

 Test Files  1 failed (1)
      Tests  4 failed | 4 passed (8)
```

The guard was also shown red *after* the fix, on a single reintroduced literal (`title: 'Find a Dataset'` reverted to `'Find NYC Dataset'` in a throwaway edit): `Tests 1 failed | 10 passed (11)`. Reverted.

### The gates, post-fix

`npm ci` run first. Measured against this repo's healthy baselines.

`npm run clean && npm run build:tsc` — exit 0:

```
> socrata-mcp-server@0.1.5 build:tsc
> tsc --outDir dist
```

`npm test` — exit 0. Baseline `Test Files 15 passed | 2 skipped (17)` / `Tests 92 passed | 9 skipped (101)`; the deltas are the new file and its 11 tests:

```
 ✓ src/tools/split-tools.test.ts (9 tests) 7ms
 ✓ src/__tests__/skill-guidance.test.ts (9 tests) 2ms
 ✓ src/__tests__/enriched-search.test.ts (7 tests) 4ms
 ✓ src/__tests__/socrata-tools.test.ts (18 tests) 13ms
 ✓ src/__tests__/search.test.ts (12 tests) 102ms
 ✓ src/__tests__/tools-schema-validation.test.ts (4 tests) 73ms
 ✓ src/__tests__/protocol-ceiling.test.ts (3 tests) 39ms
 ✓ src/__tests__/openai-initialize.test.ts (6 tests | 2 skipped) 47ms
 ✓ src/__tests__/utils.test.ts (5 tests) 4ms
 ↓ src/__tests__/integration.test.ts (6 tests | 6 skipped)
 ✓ src/__tests__/portal-text.test.ts (11 tests) 42ms
 ✓ src/__tests__/openai-mcp-integration.test.ts (4 tests) 2ms
 ✓ src/__tests__/error-handling.test.ts (3 tests) 1ms
 ✓ src/__tests__/tool-schema.test.ts (5 tests) 3ms
 ✓ src/__tests__/server-init.test.ts (2 tests) 9ms
 ↓ src/__tests__/protocol-sequence.test.ts (1 test | 1 skipped)
 ✓ test/socrata-url.test.ts (3 tests) 1ms
 ✓ test/socrata-schema.test.ts (4 tests) 2ms

 Test Files  16 passed | 2 skipped (18)
      Tests  103 passed | 9 skipped (112)
```

`npm run lint` — exit 0, exactly at baseline:

```
✖ 117 problems (0 errors, 117 warnings)
```

### Bring-up smoked on the built artifact

The entry-point gate is the one change with deploy risk, so both transports were driven from `dist/` with `DATA_PORTAL_URL` set to the second portal.

stdio (`node dist/index.js --stdio`) answered `initialize` and `tools/list` over the wire:

```
"name":"search","title":"Search data.cityofchicago.org","description":"Search the open data portal this server is configured for (data.cityofchicago.org) and return matching dataset IDs"
"name":"fetch","title":"Fetch Document from data.cityofchicago.org","description":"Retrieve full dataset metadata or record content from the open data portal this server is configured for (data.cityofchicago.org)"
"domain":{"type":"string","description":"The Socrata domain to query; defaults to the portal this server is configured for (data.cityofchicago.org)"}
```

HTTP (`node dist/index.js`) booted: `🚀 Server running on port 8123`.

## The census

`git grep -c "NYC" -- src/index.ts src/tools/socrata-tools.ts` returns 0 for both files.

Two lowercase `nyc` literals legitimately remain in `src/index.ts`, both compatibility aliases that are accepted and never advertised:

- `LEGACY_RESOURCE_URI_PREFIX = 'data://nyc/info/'`
- `ANALYZE_PROMPT_LEGACY_NAME = 'analyze_nyc_data'`

## What changed, site by site

All 26 sites in `src/index.ts` and all 4 in `src/tools/socrata-tools.ts` are handled, plus two the contract's list did not carry.

- **`tools/list` titles** now read `SEARCH_TOOL.title` / `FETCH_TOOL.title` instead of re-declaring them. The duplication is gone, not merely fixed twice.
- **Tool `title` and `description`** are getters, not literals. This is load-bearing: `src/index.ts` calls `dotenv.config()` in its module body, which runs *after* every import it makes, so anything resolving `DATA_PORTAL_URL` at module-load time reads the environment before dotenv has populated it. Lazy resolution is the only correct shape here, and the guard fails if it is lost.
- **Prompt titles, descriptions and bodies** name the configured portal. Argument descriptions dropped one city's subdivision vocabulary ("boroughs") for "districts".
- **Resource titles, descriptions and bodies** name the configured portal; the API guide's base URL and its `WHERE` example are portal-neutral.
- **Two sites the contract's list did not carry** (they spell `cityofnewyork` but not `NYC`): the `domain` parameter's example in `jsonParameters` (advertised in every `tools/list`) and in `socrataToolZodSchema` (parse-only).

### Two content decisions worth review

**The `popular-datasets` resource.** It was a hardcoded snapshot of five datasets from one city — IDs, names and publishing agencies all one portal's — served as `application/json`. Interpolating a domain cannot make that true anywhere else. Deriving it live from the catalog would put a network call inside `resources/read` and a new failure mode with it, which is out of proportion to a text phase. The resource now answers the same question by pointing at the tools that can actually answer it (`get_data` with `type: "catalog"` / `"metrics"`, then `search` / `fetch`), as `text/markdown`. **The mimeType change is client-visible.** Making it live is proposed as a follow-up, not done here.

**The `portal-overview` body** asserted a dataset count, a set of publishing agencies and a category list as fact about one portal. It now says what a Socrata portal provides, names the configured domain, lists only capabilities `get_data` actually implements (`catalog`, `metadata`, `query`, `metrics` — no invented `categories`), and ends by saying that what the portal holds is the portal's property, to be asked rather than assumed.

### Identifiers renamed, with aliases

The prompt name `analyze_nyc_data` and the three `data://nyc/info/*` URIs named a city in an identifier. Measured before renaming: nothing in this repository, the hub repository or the website addresses them — the only consumers were `src/index.ts` itself. They are renamed to `analyze_open_data` and `data://portal/info/*`; the old forms are still accepted and resolve to the current content, and `resources/read` echoes the *current* URI so nothing this server sends spells the old one. Three assertions drive that compatibility path.

## One resolver

`getDefaultDomain` was module-local in `socrata-tools.ts`, which is why `src/index.ts` could not reach it and named the portal in literal text instead. It now lives in `src/utils/portal-config.ts` — a new, pure, dependency-free module — and both files import the one implementation. It is not in `portal-info.ts` because that module pulls in axios and fetches the portal homepage; anything that needs to *name* the portal should not take a network dependency to do it.

The hardcoded fallback (`'https://data.cityofnewyork.us'` when `DATA_PORTAL_URL` is unset) is **carried over unchanged and documented**, not removed — removing it changes bring-up behaviour. See the flag below.

## Flagged, not fixed

1. **The fallback portal literal is a code default naming one deployment**, and it is inconsistent with the rest of the tree: `src/utils/portal-info.ts` throws `DATA_PORTAL_URL must be set`, `src/utils/api.ts` throws `DATA_PORTAL_URL is not configured`, and `CLAUDE.md` documents the variable as **required**. So `get_data`/`search`/`fetch` silently answer against one city when the variable is unset, while the two other paths refuse. Proposed, not done: drop the fallback and let `getDefaultDomain` throw the same way. That changes bring-up behaviour and belongs in its own phase.
2. **`src/skills/*.ts` name several cities** (`base.ts:12, :199-200, :237-238, :258, :271`; `local.ts:22`; `web.ts:14, :43-44`). Out of scope by contract: generated from `civic-ai-tools/docs/skills/*.md`, and the mentions are a deliberate multi-portal capability list, not a wrong default. The guard states this carve-out in its header and excludes only the `skill-guidance` prompt body, while still asserting that prompt is served.
3. **Every pre-existing "integration" test builds a look-alike server.** `openai-mcp-integration.test.ts` invents its own titles (`'Search Socrata Datasets'`, `'Fetch Documents'`) that never matched what `src/index.ts` returned; `protocol-sequence.test.ts` and `server-init.test.ts` construct their own `McpServer`. Before this PR nothing in the suite read the real handler surface. The new guard is the first test that does; widening the others is not this phase's work.
4. **`UNIFIED_SOCRATA_TOOL.description`** ("A unified tool to interact with Socrata open-data portals.") names no city, so it is left alone — but it also never tells the model which portal it will hit. Naming the configured domain there would help; deliberately not done, to keep the diff to the class the phase is about.
5. **The 117 lint warnings** are pre-existing and untouched.

## Premises checked

Every line reference in the contract was re-measured at `c207f55` and held: the resolver at `socrata-tools.ts:29-32` (module-local, used at `:41, :78, :128, :179, :196, :216, :269`), the four literals at `:445-446, :454-455`, the two re-declared titles at `index.ts:182, :188`, and all 26 `NYC` lines in `index.ts`. The "nothing pins these strings" finding held: `tools-schema-validation.test.ts`, `openai-mcp-integration.test.ts` and `socrata-tools.test.ts:311-314` all read the constants back into their own expectations.

One correction: the class is **larger than the 26 + 4**. It also includes the two `cityofnewyork` schema examples, and — measured by driving the surface rather than grepping it — the resource URIs, the prompt name, and the vocabulary words `borough`, `Manhattan` and `NYPD`. The full pre-fix red is 43 offences, not 30. This is the same shape as the rule the contract cites: a census scoped to one token cannot see a defect scoped to a property.

Model: Opus 5 (1M context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWaGXKnyS27JJfPXwj6pKL
